### PR TITLE
[TEST ONLY] Disable inference view tracking to accelerate as_strided op in inductor

### DIFF
--- a/c10/core/AutogradState.h
+++ b/c10/core/AutogradState.h
@@ -18,7 +18,8 @@ struct C10_API AutogradState {
       : grad_mode_(grad_mode),
         inference_mode_(inference_mode),
         fw_grad_mode_(fw_grad_mode),
-        mulithreading_enabled_(multithreading_enabled) {}
+        mulithreading_enabled_(multithreading_enabled),
+        view_replay_enabled_(false) {}
 
   void set_grad_mode(bool enabled) {
     grad_mode_ = enabled;

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1896,7 +1896,15 @@ def create_runtime_wrapper(
         else:
             args_with_synthetic_bases = args
 
-        with torch.autograd._force_original_view_tracking(True):
+        
+        if trace_joint:
+            with torch.autograd._force_original_view_tracking(True):
+                all_outs = call_func_with_args(
+                    compiled_fn,
+                    args_with_synthetic_bases,
+                    disable_amp=True,
+                )
+        else:
             all_outs = call_func_with_args(
                 compiled_fn,
                 args_with_synthetic_bases,


### PR DESCRIPTION
Backport Pytorch master commit:
https://github.com/pytorch/pytorch/pull/96478
https://github.com/pytorch/pytorch/pull/100822