### PR TITLE
[upstream #3450] [ai_generated] XPU crash on torch.linalg.ldl_solve with invalid pivots instead of raising validation error

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3788,6 +3788,16 @@ TORCH_IMPL_FUNC(linalg_ldl_solve_out)
     return;
   }
 
+  // Lapack SYTRS writes into unrelated memory if |IPIV(k)| is outside [1, N]
+  // (negative values encode 2x2 block pivots), so validate before dispatch
+  // so all devices (CPU, CUDA, XPU) get a clean error rather than a crash.
+  TORCH_CHECK(pivots.abs().ge(1).all().item<bool>(),
+              "Pivots given to ldl_solve must all satisfy |pivot| >= 1. "
+              "Did you properly pass the result of ldl_factor?");
+  TORCH_CHECK(pivots.abs().le(LD.size(-2)).all().item<bool>(),
+              "Pivots given to ldl_solve must all satisfy |pivot| <= LD.size(-2). "
+              "Did you properly pass the result of ldl_factor?");
+
   auto pivots_ = pivots.expect_contiguous();
 
   auto LD_ = at::native::borrow_else_clone(

--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -948,16 +948,6 @@ void ldl_solve_kernel(
     const Tensor& result,
     bool upper,
     bool hermitian) {
-  // Lapack SYTRS writes into unrelated memory if |IPIV(k)| is outside [1, N]
-  // (negative values encode 2x2 block pivots), so sanity-check user-provided
-  // pivots before dispatch on CPU.
-  TORCH_CHECK(pivots.abs().ge(1).all().item<bool>(),
-              "Pivots given to ldl_solve must all satisfy |pivot| >= 1. "
-              "Did you properly pass the result of ldl_factor?");
-  TORCH_CHECK(pivots.abs().le(LD.size(-2)).all().item<bool>(),
-              "Pivots given to ldl_solve must all satisfy |pivot| <= LD.size(-2). "
-              "Did you properly pass the result of ldl_factor?");
-
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
       LD.scalar_type(), "ldl_solve_kernel_cpu", [&] {
         apply_ldl_solve<scalar_t>(LD, pivots, result, upper, hermitian);


### PR DESCRIPTION
## Summary

Fix for [ZhaoqiongZ/torch-xpu-ops-exp#346](https://github.com/ZhaoqiongZ/torch-xpu-ops-exp/issues/346)

**Issue:** [upstream #3450] [ai_generated] XPU crash on torch.linalg.ldl_solve with invalid pivots instead of raising validation error

**Root Cause:** torch.linalg.ldl_solve falls back to CPU on XPU via XPUFallback.template. The upstream fix (pytorch#181032) added pivot validation (`1 <= |pivot| <= N`) inside `ldl_solve_kernel` in `BatchLinearAlgebraKernel.cpp`, which only runs on the CPU dispatch path. When XPU is used, the fallback occurs *after* the IMPL function (`linalg_ldl_solve_out` in `BatchLinearAlgebra.cpp`) copies B to result and calls `ldl_solve_stub` with the XPU device type — but the XPU fallback dispatches down to the CPU kernel without going through the validated path first, triggering a segfault in LAPACK SYTRS before validation runs.

**Failed Tests:**
- No specific test method identified; reproducer is a standalone script targeting `torch.linalg.ldl_solve` on XPU with out-of-range pivots.


---

**Diff stat:**
```
aten/src/ATen/native/BatchLinearAlgebra.cpp       | 10 ++++++++++
 aten/src/ATen/native/BatchLinearAlgebraKernel.cpp | 10 ----------
 2 files changed, 10 insertions(+), 10 deletions(-)
```


