### PR TITLE
[upstream #3379] [distributed] accuracy error in test_c10d_xccl.py

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3701,6 +3701,10 @@ Example::
               py::arg("size"),
               R"(Create a new ProcessGroupXCCL instance.)")
           .def_property_readonly(
+              "uid",
+              &::c10d::ProcessGroupXCCL::getUid,
+              R"(Return the uid.)")
+          .def_property_readonly(
               "options",
               &::c10d::ProcessGroupXCCL::getOptions,
               R"(Return the options used to create this ProcessGroupXCCL instance.)");

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1523,6 +1523,13 @@ def _get_process_group_uid(pg: ProcessGroup) -> int:
         pass
     if is_nccl_available() and isinstance(backend, ProcessGroupNCCL):
         return backend.uid
+    backend = None
+    try:
+        backend = pg._get_backend(torch.device("xpu"))
+    except RuntimeError:
+        pass
+    if is_xccl_available() and isinstance(backend, ProcessGroupXCCL):
+        return backend.uid
     return -1
 
 


### PR DESCRIPTION
## [upstream #3379] [distributed] accuracy error in test_c10d_xccl.py

Fixes https://github.com/ZhaoqiongZ/torch-xpu-ops-exp/issues/327

**Root Cause:** The `_get_process_group_uid` function in `torch/distributed/distributed_c10d.py` only handles `ProcessGroupNCCL` (CUDA backend) — it tries `pg._get_backend(torch.device('cuda'))` and checks `isinstance(backend, ProcessGroupNCCL)`. For XPU/XCCL process groups, this check fails and the function falls through to `return -1`. While `ProcessGroupXCCL` does have a C++ `getUid()` method (returning the `local_id_` counter), there is no Python `uid` property binding in `torch/csrc/distributed/c10d/init.cpp` for `ProcessGroupXCCL`, unlike `ProcessGroupNCCL` which has `.def_property_readonly('uid', &::c10d::ProcessGroupNCCL::getUid, ...)`. The XCCLTraceTest failures (exit code 10) are likely related — the trace infrastructure uses the process group uid as a key ('0', '1', ...) in the trace dict, and when uid returns -1 the trace validation logic (`pg_config['0']`) fails.

**Failed Tests:**
- `test/distributed/test_c10d_xccl.py::ProcessGroupXCCLGroupTest::test_get_uid`
- `test/distributed/test_c10d_xccl.py::XCCLTraceTest::test_batched_send_recv_op_sizes_per_coalesce0_timing_enabled_False`
- `test/distributed/test_c10d_xccl.py::XCCLTraceTest::test_batched_send_recv_op_sizes_per_coalesce0_timing_enabled_True`
- `test/distributed/test_c10d_xccl.py::XCCLTraceTest::test_batched_send_recv_op_sizes_per_coalesce1_timing_enabled_False`
- `test/distributed/test_c10d_xccl.py::XCCLTraceTest::test_batched_send_recv_op_sizes_per_coalesce1_timing_enabled_True`
- `test/distributed/test_c10d_xccl.py::XCCLTraceTest::test_long`
- `test/distributed/test_c10d_xccl.py::XCCLTraceTest::test_trace_while_active_timing_enabled_False_only_active_True`


---

**Diff stat:**
```
.ci/docker/common/install_cpython.sh               |   6 +-
 .ci/docker/manywheel/Dockerfile_2_28               |  10 -
 .ci/docker/manywheel/Dockerfile_2_28_aarch64       |   4 -
 .ci/docker/manywheel/Dockerfile_cuda_aarch64       |  10 -
 .ci/manywheel/build_env_setup.py                   |  57 ++-
 .github/labeler.yml                                |   3 -
 .github/workflows/_linux-build.yml                 |  43 +-
 .github/workflows/_linux-test.yml                  |  25 +-
 .github/workflows/pull.yml                         |   7 -
 Dockerfile                                         |  10 +-
 aten/src/ATen/CMakeLists.txt                       |   9 +-
 aten/src/ATen/core/List_inl.h                      |   2 +-
 aten/src/ATen/core/ivalue_inl.h                    |   2 +-
 aten/src/ATen/native/mps/MetalShaderLibrary.h      |  14 +-
 aten/src/ATen/native/mps/OperationUtils.mm         | 163 ++-----
 .../src/ATen/native/mps/kernels/BinaryKernel.metal |  73 ---
 aten/src/ATen/native/mps/kernels/Repeat.metal      |   5 +-
 aten/src/ATen/native/mps/operations/Attention.mm   |  42 +-
 .../src/ATen/native/mps/operations/BinaryKernel.mm |  35 --
 aten/src/ATen/native/mps/operations/BinaryOps.mm   |  32 ++
 aten/src/ATen/native/mps/operations/Col2Im.mm      |  15 +-
 aten/src/ATen/native/mps/operations/Repeat.mm      |   3 +-
 aten/src/ATen/native/native_functions.yaml         |  36 +-
 c10/cuda/CUDAEvent.h                               |  13 +-
 c10/metal/common.h                                 |  34 +-
 c10/metal/indexing.h                               | 489 +++++++++-----------
 docs/source/conf.py                                |  18 +-
 docs/source/distributed.optim.md                   |   5 -
 docs/source/elastic/{events.md => events.rst}      |  31 +-
 .../elastic/{rendezvous.md => rendezvous.rst}      |  87 ++--
 docs/source/notes/mps.md                           |  43 --
 docs/source/notes/mps.rst                          |  44 ++
 docs/source/profiler.md                            |  16 +-
 docs/source/quantization-support.md                |  19 +-
 docs/source/{torch.md => torch.rst}                | 417 ++++++-----------
 .../torch_openreg/csrc/CMakeLists.txt              |   2 +-
 .../csrc/distributed/c10d/ProcessGroupOCCL.cpp     |   8 +
 .../csrc/distributed/c10d/ProcessGroupOCCL.hpp     |   5 +
 .../torch_openreg/torch_openreg/__init__.py        |   7 +-
 .../torch_openreg/torch_openreg/csrc/Module.cpp    |  21 +-
 .../torch_openreg/csrc/distributed/init.cpp        |  29 --
 .../torch_openreg/csrc/distributed/init.hpp        |   9 -
 test/dynamo/test_after_aot.py                      |  95 ++++
 test/dynamo/test_subclasses.py                     |  15 -
 ...ools-TestPartialPy.test_nested_optimization_bug |   0
 ...tPartialPySubclass.test_nested_optimization_bug |   0
 test/inductor/test_codegen_triton.py               |  47 --
 test/inductor/test_cpu_repro.py                    |  42 +-
 test/inductor/test_cudagraph_trees.py              |  39 +-
 test/inductor/test_torchinductor.py                |  33 +-
 test/test_cuda.py                                  | 123 +----
 test/test_flop_counter.py                          |  87 ----
 test/test_mps.py                                   | 496 +--------------------
 test/test_torch.py                                 |   9 +
 third_party/kineto                                 |   2 +-
 torch/_decomp/decompositions.py                    |   8 +-
 torch/_dynamo/debug_utils.py                       |  13 +-
 torch/_dynamo/polyfills/tensor.py                  |  10 -
 torch/_dynamo/repro/after_aot.py                   |  94 ++++
 torch/_dynamo/variables/misc.py                    |   3 -
 torch/_higher_order_ops/flex_attention.py          |  78 ++--
 torch/_inductor/codegen/cpp.py                     |   4 +-
 torch/_inductor/codegen/cpp_wrapper_cpu.py         |  40 +-
 .../_inductor/codegen/cpp_wrapper_cpu_array_ref.py |  10 +-
 torch/_inductor/codegen/cpp_wrapper_gpu.py         |  41 +-
 torch/_inductor/codegen/simd.py                    | 120 +++--
 torch/_inductor/codegen/triton.py                  | 160 +++----
 torch/_inductor/compile_fx.py                      |  14 +-
 torch/_inductor/compile_fx_async.py                |   1 +
 torch/_inductor/compile_fx_ext.py                  |   1 +
 torch/_inductor/compile_fx_subproc.py              |   1 +
 torch/_inductor/config.py                          |   7 +-
 torch/_inductor/cudagraph_trees.py                 |  28 +-
 torch/_inductor/fx_passes/overlap_scheduling.py    |   4 +-
 torch/_inductor/loop_body.py                       |  16 +-
 torch/_inductor/output_code.py                     |  51 ++-
 torch/_inductor/scheduler.py                       | 193 +-------
 torch/_inductor/utils.py                           |  23 -
 torch/_jit_internal.py                             |   4 +-
 torch/autograd/forward_ad.py                       |   2 +-
 torch/autograd/graph.py                            |   2 +-
 torch/csrc/distributed/c10d/init.cpp               |   4 +
 torch/csrc/distributed/c10d/reducer.hpp            |   2 +-
 torch/distributed/_functional_collectives.py       |   2 +-
 torch/distributed/checkpoint/planner.py            |   6 +-
 torch/distributed/checkpoint/storage.py            |   4 +-
 torch/distributed/distributed_c10d.py              |  20 +-
 torch/distributed/optim/utils.py                   |   6 +-
 torch/distributed/rpc/api.py                       |  10 +-
 torch/export/_draft_export.py                      |   4 +-
 torch/export/unflatten.py                          |   2 +-
 torch/nn/functional.py                             |   4 +-
 .../_internal/common_methods_invocations.py        |  41 +-
 torch/utils/_runtime_estimation.py                 |  12 +-
 torch/utils/flop_counter.py                        |  20 +-
 torch/utils/hipify/cuda_to_hip_mappings.py         |   1 -
 96 files changed, 1324 insertions(+), 2633 deletions(-)
```


