### PR TITLE
[upstream #2795] Histc raises error with integer input when deterministic algorithm is enabled

### DIFF
--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8039,6 +8039,8 @@ def meta_histc(input, bins=100, min=0, max=0):
         )
     if device_hint(input) == "cuda" and input.is_floating_point():
         utils.alert_not_deterministic("_histc_cuda with floating point input")
+    if device_hint(input) == "xpu" and input.is_floating_point():
+        utils.alert_not_deterministic("_histc_xpu with floating point input")
     torch._check(
         isinstance(bins, IntLike),
         lambda: f"{fn_name}: argument 'bins' must be int, not {type(bins)}",


### PR DESCRIPTION
## [upstream #2795] Histc raises error with integer input when deterministic algorithm is enabled

Fixes https://github.com/ZhaoqiongZ/torch-xpu-ops-exp/issues/193

**Root Cause:** The XPU histc implementation in `SummaryOps.cpp` unconditionally calls `globalContext().alertNotDeterministic("_histc_xpu")` for all input dtypes, whereas the CUDA implementation correctly guards the alert with `if (at::isFloatingType(self.scalar_type()))`. Integer atomicAdd is exact and order-independent, making integer histc deterministic. Additionally, `torch/_meta_registrations.py` has a Python-level determinism guard for CUDA+float but no equivalent guard for XPU, so even fixing C++ alone may leave a gap.



---

**Diff stat:**
```
torch/_meta_registrations.py | 2 ++
 1 file changed, 2 insertions(+)
```


