### PR TITLE
[upstream_ut] test/dynamo/test_higher_order_ops.py test_dropout failed with RuntimeError: CUDA not available

### DIFF
--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -575,6 +575,9 @@ def create_functionalized_rng_ops_wrapper(
         ):
             return append_rng_offsets(*func(*primals_fwd_seed_fwd_base_offset[:-2]))
 
+    if not torch.cuda.is_available():
+        return func, args, args_descs
+
     if trace_joint:
         # Get the current seed and offset to setup tracing.
         fwd_seed, fwd_base_offset = CUDARngStateHelper.get_torch_state_as_tuple(


### PR DESCRIPTION
## [upstream_ut] test/dynamo/test_higher_order_ops.py test_dropout failed with RuntimeError: CUDA not available

Fixes https://github.com/intel/torch-xpu-ops/issues/3361

**Root Cause:** The test `test_dropout` uses `@requires_cuda_and_triton` which skips when CUDA is unavailable, but the XPU CI environment has CUDA libraries present (satisfying the decorator at module-load time) yet no working CUDA GPU. When AOTAutograd's `create_functionalized_rng_ops_wrapper` is invoked with `functionalize_rng_ops=True`, it unconditionally calls `CUDARngStateHelper.get_torch_state_as_tuple` (graph_capture_wrappers.py:580) which hard-raises `RuntimeError('CUDA not available')` with no CUDA guard. The function `get_torch_state_as_tuple` is CUDA-only but `functionalize_rng_ops` is a generic config flag that can be activated on non-CUDA backends.

**Failed Tests:**
- `test/dynamo/test_higher_order_ops.py::ActivationCheckpointingTests::test_dropout`


---

**Diff stat:**
```
torch/_dynamo/variables/builder.py                       | 3 ++-
 torch/_functorch/_aot_autograd/graph_capture_wrappers.py | 3 +++
 2 files changed, 5 insertions(+), 1 deletion(-)
```


