### PR TITLE
torch._dynamo.exc.InternalTorchDynamoError: TypeError: cannot create weak reference to 'torch.Event' object

### DIFF
--- a/torch/csrc/xpu/Event.cpp
+++ b/torch/csrc/xpu/Event.cpp
@@ -45,6 +45,9 @@ static PyObject* THXPEvent_pynew(
 }
 
 static void THXPEvent_dealloc(THXPEvent* self) {
+  if (self->weakreflist != nullptr) {
+    PyObject_ClearWeakRefs((PyObject*)self);
+  }
   {
     pybind11::gil_scoped_release no_gil{};
     self->xpu_event.~XPUEvent();
@@ -168,7 +171,7 @@ static PyTypeObject THXPEventType = {
     nullptr, /* tp_traverse */
     nullptr, /* tp_clear */
     nullptr, /* tp_richcompare */
-    0, /* tp_weaklistoffset */
+    offsetof(THXPEvent, weakreflist), /* tp_weaklistoffset */
     nullptr, /* tp_iter */
     nullptr, /* tp_iternext */
     THXPEvent_methods, /* tp_methods */


### PR DESCRIPTION
## torch._dynamo.exc.InternalTorchDynamoError: TypeError: cannot create weak reference to 'torch.Event' object

Fixes https://github.com/intel/torch-xpu-ops/issues/1969

**Root Cause:** torch.Event for XPU (THXPEvent) does not support weak references. The XPU PyTypeObject THXPEventType has tp_weaklistoffset set to 0, meaning Python's weakref module cannot create weak references to XPU Event objects. When Dynamo's register_user_object() tries to weakref-track a torch.Event (XPU) during tracing, it gets a TypeError which is surfaced as an InternalTorchDynamoError.

**Failed Tests:**
- `test/dynamo/test_ctx_manager.py::CtxManagerTests::test_gpu_event_across_graph_break`


---

**Diff stat:**
```
torch/csrc/xpu/Event.cpp | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)
```


