### PR TITLE
[upstream_ut] MetadataMismatchError in TestFakeTensor of test_ops.py

### DIFF
--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -586,6 +586,12 @@ TORCH_LIBRARY_IMPL(aten, AutocastXPU, m) {
 
   AT_FORALL_PROMOTE(_KERNEL_XPU_PROMOTE)
 
+  KERNEL_XPU(pinverse, fp32)
+  KERNEL_XPU(linalg_pinv, atol_rtol_tensor, fp32)
+  KERNEL_XPU(linalg_pinv, atol_rtol_float, fp32)
+  KERNEL_XPU(linalg_pinv, fp32)
+  KERNEL_XPU(linalg_pinv, rcond_tensor, fp32)
+
   m.impl(TORCH_SELECTIVE_NAME("aten::binary_cross_entropy"),
          TORCH_FN((&at::autocast::binary_cross_entropy_banned)));
 }


### PR DESCRIPTION
## [upstream_ut] MetadataMismatchError in TestFakeTensor of test_ops.py

Fixes https://github.com/intel/torch-xpu-ops/issues/1963

**Root Cause:** linalg_pinv and pinverse are not registered in any XPU autocast policy in aten/src/ATen/autocast_mode.cpp. For CUDA, these ops are handled via fp32 policy but the equivalent XPU registration is missing. Without an explicit XPU autocast registration, the real kernel respects the active autocast dtype (float16) while the fake tensor dispatch falls through without dtype casting, producing a dtype mismatch (float32 vs float16). The bilinear failure likely follows the same pattern where the promote policy for XPU is not being observed by FakeTensor.

**Failed Tests:**
- `test_ops.py::TestFakeTensorXPU::test_fake_autocast_linalg_pinv_xpu_float32`
- `test_ops.py::TestFakeTensorXPU::test_fake_autocast_pinverse_xpu_float32`
- `test_ops.py::TestFakeTensorXPU::test_fake_crossref_backward_amp_nn_functional_bilinear_xpu_float32`


---

**Diff stat:**
```
aten/src/ATen/autocast_mode.cpp | 6 ++++++
 1 file changed, 6 insertions(+)
```


