### PR TITLE
[upstream_ut]  torch._inductor.exc.InductorError: CppCompileError: C++ compile error 

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -546,19 +546,27 @@ class CppWrapperCpu(PythonWrapperCodegen):
         if config.aot_inductor.custom_ops_to_c_shims:
             # custom_ops_to_c_shims contains declaration of custom ops with C shim.
             # TODO: this could be auto-generated from a passed-in custom op schema
-            custom_c_shims = list(
-                chain(*config.aot_inductor.custom_ops_to_c_shims.values())
-            )
-            declarations = "\n".join(
-                [f"extern {textwrap.dedent(shim)};" for shim in custom_c_shims]
-            )
-            self.prefix.splice(
-                f"""
-                extern "C" {{
-                    {declarations}
-                }}
-                """
-            )
+            # Filter shims to only include those for the current device and CPU,
+            # to avoid compile errors from declarations for unavailable devices.
+            custom_c_shims = [
+                shim
+                for shim in chain(
+                    *config.aot_inductor.custom_ops_to_c_shims.values()
+                )
+                if f"aoti_torch_{self.device}_" in shim
+                or "aoti_torch_cpu_" in shim
+            ]
+            if custom_c_shims:
+                declarations = "\n".join(
+                    [f"extern {textwrap.dedent(shim)};" for shim in custom_c_shims]
+                )
+                self.prefix.splice(
+                    f"""
+                    extern "C" {{
+                        {declarations}
+                    }}
+                    """
+                )
         if V.graph.aot_mode:
             self.prefix.writeline("namespace torch::aot_inductor {")
         if not V.graph.is_const_graph:


### PR DESCRIPTION
## [upstream_ut]  torch._inductor.exc.InductorError: CppCompileError: C++ compile error 

Fixes https://github.com/intel/torch-xpu-ops/issues/2609

**Root Cause:** In cpp_wrapper_cpu.py write_prefix(), when custom_ops_to_c_shims contains shims for multiple devices (cpu, cuda, xpu), all shims are unconditionally emitted as extern declarations in the generated C++ header. On an XPU-only platform without CUDA headers, the cuda shim declaration causes a C++ compile error during AotCodeCompiler.compile().

**Failed Tests:**
- `inductor/test_aot_inductor_custom_ops.py::AOTInductorTestABICompatibleGpu::test_custom_op_square_xpu`


---

**Diff stat:**
```
torch/_inductor/codegen/cpp_wrapper_cpu.py | 34 ++++++++++++++++++------------
 1 file changed, 21 insertions(+), 13 deletions(-)
```


