### PR TITLE
[upstream_ut]  RuntimeError: Cannot swap t2 because it has weakref associated with it ; RuntimeError: _apply(): Co


### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -985,11 +985,19 @@ class Module:
                     )
                     torch.utils.swap_tensors(param, param_applied)
                 except Exception as e:
-                    if param_grad is not None:
-                        param.grad = param_grad
-                    raise RuntimeError(
-                        f"_apply(): Couldn't swap {self._get_name()}.{key}"
-                    ) from e
+                    if isinstance(param, FakeTensor):
+                        # FakeTensors may have weakrefs (from dispatch cache
+                        # eviction finalizers) that prevent swap_tensors.
+                        # Fall back to set_data which is safe for FakeTensors.
+                        if param_grad is not None:
+                            param.grad = param_grad
+                        param.data = param_applied
+                    else:
+                        if param_grad is not None:
+                            param.grad = param_grad
+                        raise RuntimeError(
+                            f"_apply(): Couldn't swap {self._get_name()}.{key}"
+                        ) from e
                 out_param = param
             elif p_should_use_set_data:
                 param.data = param_applied


### PR DESCRIPTION
## [upstream_ut]  RuntimeError: Cannot swap t2 because it has weakref associated with it ; RuntimeError: _apply(): Co


Fixes https://github.com/intel/torch-xpu-ops/issues/2712

**Root Cause:** When FakeTensorMode dispatches operations, it attaches weakref.finalize callbacks to FakeTensor objects (fake_tensor.py:1709) for dispatch cache eviction. When module._apply() calls fn(param) to produce param_applied (a FakeTensor), that tensor has a weakref finalize attached. swap_tensors() (torch/utils/__init__.py:46) rejects any tensor with an associated weakref, raising RuntimeError. The non_strict_export_fake_tensor_tracker WeakSet in FakeTensorMode may also hold weakrefs on freshly created FakeTensors.

**Failed Tests:**
- `test/test_fake_tensor.py::FakeTensorOperatorInvariants::test_module_to`
- `third_party/torch-xpu-ops/test/xpu/test_fake_tensor_xpu.py::FakeTensorOperatorInvariants::test_module_to`


---

**Diff stat:**
```
torch/nn/modules/module.py | 18 +++++++++++++-----
 1 file changed, 13 insertions(+), 5 deletions(-)
```


