### PR TITLE
[upstream #2779] Accuracy failures in logspace op

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5605,7 +5605,10 @@ def logspace(
         pin_memory=pin_memory,
         requires_grad=requires_grad,
     )
-    return _maybe_convert_to_dtype(torch.pow(base, ret), dtype)  # type: ignore[arg-type,return-value]
+    result = torch.pow(base, ret)
+    if utils.is_integer_dtype(dtype):
+        result = torch.round(result)
+    return _maybe_convert_to_dtype(result, dtype)  # type: ignore[arg-type,return-value]
 
 
 @overload


### PR DESCRIPTION
## [upstream #2779] Accuracy failures in logspace op

Fixes https://github.com/intel-sandbox/torch-xpu-ops-exp/issues/191

**Root Cause:** The logspace decomposition in torch/_refs/__init__.py computes pow(base, linspace(...)) in float64 then truncates to integer dtype via _maybe_convert_to_dtype. For integer dtypes, floating-point precision errors in pow() produce values like 99.99999999 which truncate to 99 instead of 100, causing one-off accuracy failures.

**Failed Tests:**
- `test_decomp_xpu.py::TestDecompXPU::test_comprehensive_logspace_tensor_overload_xpu_int16`
- `test_decomp_xpu.py::TestDecompXPU::test_comprehensive_logspace_tensor_overload_xpu_int32`
- `test_decomp_xpu.py::TestDecompXPU::test_comprehensive_logspace_tensor_overload_xpu_int64`
- `test_decomp_xpu.py::TestDecompXPU::test_comprehensive_logspace_xpu_int16`
- `test_decomp_xpu.py::TestDecompXPU::test_comprehensive_logspace_xpu_int32`
- `test_decomp_xpu.py::TestDecompXPU::test_comprehensive_logspace_xpu_int64`
- `test_decomp_xpu.py::TestDecompXPU::test_quick_logspace_tensor_overload_xpu_int16`
- `test_decomp_xpu.py::TestDecompXPU::test_quick_logspace_tensor_overload_xpu_int32`
- `test_decomp_xpu.py::TestDecomXPU::test_quick_logspace_tensor_overload_xpu_int64`
- `test_decomp_xpu.py::TestDecompXPU::test_quick_logspace_xpu_int16`
- `test_decomp_xpu.py::TestDecompXPU::test_quick_logspace_xpu_int32`
- `test_decomp_xpu.py::TestDecompXPU::test_quick_logspace_xpu_int64`


---

**Diff stat:**
```
torch/_refs/__init__.py | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)
```


