### PR TITLE
[upstream #3489] [release/2.12] PT2E INT8 accuracy regression on shufflenet_v2_x1_0 (XPU): Acc@1 66.5 → 0.09 between release/2.11 and 2.12.0+xpu

### DIFF
--- a/torch/_inductor/mkldnn_lowerings.py
+++ b/torch/_inductor/mkldnn_lowerings.py
@@ -598,21 +598,48 @@ def register_onednn_fusion_ops():
                 x_scale = V.graph.add_tensor_constant(
                     torch.tensor(x_scale, dtype=torch.float32), name="x_scale"
                 )
+            else:
+                x_scale_size = x_scale.get_size()
+                if len(x_scale_size) == 0 or all(dim == 1 for dim in x_scale_size):
+                    x_scale = _convert_to_0d_constant(x_scale, torch.float32, "_0d")
+                else:
+                    x_scale.realize()
+                assert len(x_scale.get_size()) in [0, 1], "x_scale must be 0D or 1D"
 
             if x_zp is None:
                 x_zp = V.graph.add_tensor_constant(
                     torch.tensor(0, dtype=torch.int32), name="x_zp"
                 )
-            if not isinstance(x_zp, ir.TensorBox):
+            elif not isinstance(x_zp, ir.TensorBox):
                 assert type(x_zp) is int
                 x_zp = V.graph.add_tensor_constant(
                     torch.tensor(x_zp, dtype=torch.int32), name="x_zp"
                 )
+            else:
+                x_zp_size = x_zp.get_size()
+                if len(x_zp_size) == 0 or all(dim == 1 for dim in x_zp_size):
+                    x_zp = _convert_to_0d_constant(x_zp, torch.int32, "_0d")
+                else:
+                    x_zp.realize()
 
             if w_zp is None:
                 w_zp = V.graph.add_tensor_constant(
                     torch.tensor(0, dtype=torch.int32), name="w_zp"
                 )
+            w_scale.realize()
+            w_zp.realize()
+            if w_zp.get_dtype() != torch.int32:
+                if isinstance(
+                    ir.InputsKernel.unwrap_storage_for_input(w_zp),
+                    ir.ConstantBuffer,
+                ):
+                    w_zp_tensor = V.graph.constants[w_zp.get_name()].to(torch.int32)
+                    w_zp = V.graph.add_tensor_constant(
+                        torch.tensor(w_zp_tensor, dtype=torch.int32),
+                        name=w_zp.get_name(),
+                    )
+                else:
+                    w_zp = to_dtype(w_zp, torch.int32)
 
             return TensorBox.create(
                 mkldnn_ir.QConvPointWisePT2E.create(
@@ -671,21 +698,48 @@ def register_onednn_fusion_ops():
                 x_scale = V.graph.add_tensor_constant(
                     torch.tensor(x_scale, dtype=torch.float32), name="x_scale"
                 )
+            else:
+                x_scale_size = x_scale.get_size()
+                if len(x_scale_size) == 0 or all(dim == 1 for dim in x_scale_size):
+                    x_scale = _convert_to_0d_constant(x_scale, torch.float32, "_0d")
+                else:
+                    x_scale.realize()
+                assert len(x_scale.get_size()) in [0, 1], "x_scale must be 0D or 1D"
 
             if x_zp is None:
                 x_zp = V.graph.add_tensor_constant(
                     torch.tensor(0, dtype=torch.int32), name="x_zp"
                 )
-            if not isinstance(x_zp, ir.TensorBox):
+            elif not isinstance(x_zp, ir.TensorBox):
                 assert type(x_zp) is int
                 x_zp = V.graph.add_tensor_constant(
                     torch.tensor(x_zp, dtype=torch.int32), name="x_zp"
                 )
+            else:
+                x_zp_size = x_zp.get_size()
+                if len(x_zp_size) == 0 or all(dim == 1 for dim in x_zp_size):
+                    x_zp = _convert_to_0d_constant(x_zp, torch.int32, "_0d")
+                else:
+                    x_zp.realize()
 
             if w_zp is None:
                 w_zp = V.graph.add_tensor_constant(
                     torch.tensor(0, dtype=torch.int32), name="w_zp"
                 )
+            w_scale.realize()
+            w_zp.realize()
+            if w_zp.get_dtype() != torch.int32:
+                if isinstance(
+                    ir.InputsKernel.unwrap_storage_for_input(w_zp),
+                    ir.ConstantBuffer,
+                ):
+                    w_zp_tensor = V.graph.constants[w_zp.get_name()].to(torch.int32)
+                    w_zp = V.graph.add_tensor_constant(
+                        torch.tensor(w_zp_tensor, dtype=torch.int32),
+                        name=w_zp.get_name(),
+                    )
+                else:
+                    w_zp = to_dtype(w_zp, torch.int32)
 
             if (
                 binary_attr == "sum"
@@ -795,15 +849,19 @@ def register_onednn_fusion_ops():
                 )
             w_scale.realize()
             w_zp.realize()
-            if w_zp.get_dtype() != torch.int32 and isinstance(
-                ir.InputsKernel.unwrap_storage_for_input(w_zp),
-                ir.ConstantBuffer,
-            ):
-                # W_zp might be a ConstantBuffer with int64, convert it to int32
-                w_zp_tensor = V.graph.constants[w_zp.get_name()].to(torch.int32)
-                w_zp = V.graph.add_tensor_constant(  # type: ignore[assignment]
-                    torch.tensor(w_zp_tensor, dtype=torch.int32), name=w_zp.get_name()
-                )
+            if w_zp.get_dtype() != torch.int32:
+                if isinstance(
+                    ir.InputsKernel.unwrap_storage_for_input(w_zp),
+                    ir.ConstantBuffer,
+                ):
+                    # W_zp might be a ConstantBuffer with int64, convert it to int32
+                    w_zp_tensor = V.graph.constants[w_zp.get_name()].to(torch.int32)
+                    w_zp = V.graph.add_tensor_constant(  # type: ignore[assignment]
+                        torch.tensor(w_zp_tensor, dtype=torch.int32),
+                        name=w_zp.get_name(),
+                    )
+                else:
+                    w_zp = to_dtype(w_zp, torch.int32)
 
             bias_dtype = None if bias is None else bias.get_dtype()
             choices: list[ChoiceCaller] = []
@@ -1102,14 +1160,18 @@ def register_onednn_fusion_ops():
             # https://github.com/pytorch/pytorch/blob/f353d17755ed23b02924c962a86ff99a3405fe10/torch/_inductor/graph.py#L570-L577
             w_scale.realize()
             w_zp.realize()
-            if w_zp.get_dtype() != torch.int32 and isinstance(
-                ir.InputsKernel.unwrap_storage_for_input(w_zp),
-                ir.ConstantBuffer,
-            ):
-                w_zp_tensor = V.graph.constants[w_zp.get_name()].to(torch.int32)
-                w_zp = V.graph.add_tensor_constant(  # type: ignore[assignment]
-                    torch.tensor(w_zp_tensor, dtype=torch.int32), name=w_zp.get_name()
-                )
+            if w_zp.get_dtype() != torch.int32:
+                if isinstance(
+                    ir.InputsKernel.unwrap_storage_for_input(w_zp),
+                    ir.ConstantBuffer,
+                ):
+                    w_zp_tensor = V.graph.constants[w_zp.get_name()].to(torch.int32)
+                    w_zp = V.graph.add_tensor_constant(  # type: ignore[assignment]
+                        torch.tensor(w_zp_tensor, dtype=torch.int32),
+                        name=w_zp.get_name(),
+                    )
+                else:
+                    w_zp = to_dtype(w_zp, torch.int32)
             if binary_attr == "sum":
                 if output_dtype in [
                     torch.float32,


### PR DESCRIPTION
## [upstream #3489] [release/2.12] PT2E INT8 accuracy regression on shufflenet_v2_x1_0 (XPU): Acc@1 66.5 → 0.09 between release/2.11 and 2.12.0+xpu

Fixes https://github.com/intel-sandbox/torch-xpu-ops-exp/issues/364

**Root Cause:** The regression is caused by commit b3bc797d23f which added qconv_pointwise.tensor variant support. When PT2E quantization produces tensor-typed x_scale/x_zp (x_scale_zp_are_tensors=True path), the new lowering handles them but does not ensure w_zp is properly converted to int32 for the qconv path on XPU (unlike the qlinear path which has explicit dtype conversion at L798-806). Additionally, the TensorMeta construction failure in select_algorithm.py for XPU extern kernels means benchmarking requests get empty metas, potentially causing incorrect algorithm/kernel selection for grouped/depthwise convolutions like those in shufflenet.



---

**Diff stat:**
```
torch/_inductor/mkldnn_lowerings.py | 100 +++++++++++++++++++++++++++++-------
 1 file changed, 81 insertions(+), 19 deletions(-)
```


