### PR TITLE
[upstream #3137] [upstream_ut]  RuntimeError: expected scalar type Half but found Float

### DIFF
--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -487,7 +487,9 @@ class TransformerEncoder(Module):
             why_not_sparsity_fast_path = (
                 "src_key_padding_mask and mask were both supplied"
             )
-        elif torch.is_autocast_enabled():
+        elif torch.is_autocast_enabled() or torch.is_autocast_enabled(
+            src.device.type
+        ):
             why_not_sparsity_fast_path = "autocast is enabled"
 
         if not why_not_sparsity_fast_path:
@@ -862,7 +864,9 @@ class TransformerEncoderLayer(Module):
             why_not_sparsity_fast_path = "neither src_key_padding_mask nor src_mask are not supported with NestedTensor input"
         elif self.self_attn.num_heads % 2 == 1:
             why_not_sparsity_fast_path = "num_head is odd"
-        elif torch.is_autocast_enabled():
+        elif torch.is_autocast_enabled() or torch.is_autocast_enabled(
+            src.device.type
+        ):
             why_not_sparsity_fast_path = "autocast is enabled"
         elif any(
             len(getattr(m, "_forward_hooks", {}))


### PR DESCRIPTION
## [upstream #3137] [upstream_ut]  RuntimeError: expected scalar type Half but found Float

Fixes https://github.com/intel-sandbox/torch-xpu-ops-exp/issues/270

**Root Cause:** torch.is_autocast_enabled() at transformer.py:865 (and :490) checks only the default device type (cuda) for autocast. When XPU autocast is active, this returns False, so the fastpath is not disabled. The fused _transformer_encoder_layer_fwd then receives fp16 src (cast by autocast) alongside fp32 weights, causing the dtype mismatch.

**Failed Tests:**
- `test_transformers_xpu.py::TestTransformersXPU::test_transformerencoder_fastpath_use_torchscript_False_enable_nested_tensor_True_use_autocast_True_d_model_12_xpu`
- `test_transformers_xpu.py::TestTransformersXPU::test_transformerencoder_fastpath_use_torchscript_False_enable_nested_tensor_False_use_autocast_True_d_model_256_xpu`
- `test_transformers_xpu.py::TestTransformersXPU::test_transformerencoder_fastpath_use_torchscript_False_enable_nested_tensor_False_use_autocast_True_d_model_12_xpu`
- `test_transformers_xpu.py::TestTransformersXPU::test_transformerencoder_fastpath_use_torchscript_False_enable_nested_tensor_True_use_autocast_True_d_model_256_xpu`


---

**Diff stat:**
```
torch/nn/modules/transformer.py | 8 ++++++--
 1 file changed, 6 insertions(+), 2 deletions(-)
```


