### PR TITLE
[upstream #2720] [upstream_ut] RuntimeError: false INTERNAL ASSERT FAILED at "/pytorch/aten/src/ATen/native/DispatchStub.cpp":275

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3480,7 +3480,6 @@ class TestBinaryUfuncs(TestCase):
             raise AssertionError("m is intentionally a scalar")
         self.assertEqual(torch.pow(2, m), 2**m)
 
-    @skipXPU
     def test_ldexp(self, device):
         # random values
         mantissas = torch.randn(64, device=device)


### PR DESCRIPTION
## [upstream #2720] [upstream_ut] RuntimeError: false INTERNAL ASSERT FAILED at "/pytorch/aten/src/ATen/native/DispatchStub.cpp":275

Fixes https://github.com/intel-sandbox/torch-xpu-ops-exp/issues/180

**Root Cause:** The XPU ldexp kernel is already implemented and registered in torch-xpu-ops (src/ATen/native/xpu/BinaryOps.cpp:80, kernel in src/ATen/native/xpu/sycl/BinaryMiscOpsKernels.cpp:158). The test failure occurred because the REGISTER_XPU_DISPATCH(ldexp_stub) static initializer wasn't running at test time, likely due to a build configuration issue in the test environment. PR #171238 added @skipXPU as a workaround, but the kernel is fully implemented.

**Failed Tests:**
- `test/test_binary_ufuncs.py::TestBinaryUfuncsXPU::test_ldexp_xpu`


---

**Diff stat:**
```
test/test_binary_ufuncs.py | 1 -
 1 file changed, 1 deletion(-)
```


