### PR TITLE
[cuda_xpu_alignment] GroupNorm with num_groups=0 raises ZeroDivisionError instead of ValueError

### DIFF
--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -303,6 +303,8 @@ class GroupNorm(Module):
     ) -> None:
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
+        if num_groups <= 0:
+            raise ValueError("num_groups must be a positive integer")
         if num_channels % num_groups != 0:
             raise ValueError(
                 f"num_channels ({num_channels}) must be divisible by num_groups ({num_groups})"


### PR DESCRIPTION
## [cuda_xpu_alignment] GroupNorm with num_groups=0 raises ZeroDivisionError instead of ValueError

Fixes https://github.com/intel-sandbox/agentic_xpu/issues/1

**Root Cause:** In torch/nn/modules/normalization.py line 306, the constructor checks `num_channels % num_groups != 0` before validating that num_groups is positive. When num_groups=0, the modulo operation raises ZeroDivisionError before any validation can catch the invalid input.



---

**Diff stat:**
```
torch/nn/modules/normalization.py | 2 ++
 1 file changed, 2 insertions(+)
```


