### PR TITLE
[cuda_xpu_alignment] Fix `replication_pad{2d,3d}` meta accepting negative output dims

### DIFF
--- a/aten/src/ATen/native/ReplicationPadding.cpp
+++ b/aten/src/ATen/native/ReplicationPadding.cpp
@@ -111,7 +111,7 @@ TORCH_META_FUNC(replication_pad2d) (
   int64_t oheight = iheight + pad_t + pad_b;
   int64_t owidth  = iwidth + pad_l + pad_r;
 
-  TORCH_CHECK(owidth >= 1 || oheight >= 1,
+  TORCH_CHECK(owidth >= 1 && oheight >= 1,
       "input (H: ", iheight, ", W: ", iwidth, " ) is too small."
       " Calculated output H: ", oheight, " W: ", owidth);
 
@@ -157,7 +157,7 @@ TORCH_META_FUNC(replication_pad3d) (
   int64_t oheight = iheight + ptop + pbottom;
   int64_t owidth  = iwidth + pleft + pright;
 
-  TORCH_CHECK(owidth >= 1 || oheight >= 1 || odepth >= 1,
+  TORCH_CHECK(owidth >= 1 && oheight >= 1 && odepth >= 1,
       "input (D: ", idepth, " H: ", iheight, ", W: ", iwidth,
       ") is too small."
       " Calculated output D: ", odepth, " H: ", oheight, " W: ", owidth);

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2177,7 +2177,7 @@ def _pad2d_common(input, padding, *, is_reflection):
         )
 
     torch._check(
-        output_w >= 1 or output_h >= 1,
+        output_w >= 1 and output_h >= 1,
         lambda: (
             f"input (H: {input_h} W: {input_w}) is too small. "
             f"Calculated output H: {output_h} W: {output_w}"
@@ -2311,7 +2311,7 @@ def _pad3d_common(input, padding, *, is_reflection):
         )
 
     torch._check(
-        output_w >= 1 or output_h >= 1 or output_d >= 1,
+        output_w >= 1 and output_h >= 1 and output_d >= 1,
         lambda: (
             f"input (D: {input_d} H: {input_h} W: {input_w}) is too small. "
             f"Calculated output D: {output_d} H: {output_h} W: {output_w}"


### PR DESCRIPTION
## [cuda_xpu_alignment] Fix `replication_pad{2d,3d}` meta accepting negative output dims

Fixes https://github.com/intel-sandbox/agentic_xpu/issues/2

**Root Cause:** The TORCH_CHECK / torch._check for output dimensions in replication_pad2d and replication_pad3d uses || (or) instead of && (and). This means the check passes if ANY dimension is >= 1, when it should require ALL dimensions to be >= 1. When only one dimension is negative, the check passes and a tensor with negative dimensions is created, causing downstream failures in FakeTensor/torch.compile.



---

**Diff stat:**
```
aten/src/ATen/native/ReplicationPadding.cpp | 6 +++---
 torch/_meta_registrations.py                | 6 +++---
 2 files changed, 6 insertions(+), 6 deletions(-)
```