### PR TITLE
[cuda_xpu_alignment] Fix Triton HOP clone for strided mutated views (#184050)

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -477,8 +477,8 @@ def forward(self, x_1, output_1):
 
             output_code = log_stream.getvalue()
 
-        FileCheck().check("del buf3").check(
-            "dual_output_kernel_with_inline_asm_0.run(x_1, buf0,"
+        FileCheck().check_regex(r"del buf[0-9]*").check_regex(
+            r"dual_output_kernel_with_inline_asm_0\.run\(x_1, buf[0-9]*, buf[0-9]*,"
         ).run(output_code)
 
         eager_result = f(t.clone())[0]
@@ -1288,6 +1288,82 @@ def forward(self, x_1, output_1):
         eager_out = f(inp)
         compiled_out = torch.compile(f)(inp)
         self.assertEqual(compiled_out, eager_out)
+
+    @requires_gpu
+    def test_triton_kernel_mutates_strided_intermediate(self):
+        @triton.jit
+        def add_one_strided_kernel(
+            in_ptr,
+            out_ptr,
+            n_cols: tl.constexpr,
+            stride_b: tl.constexpr,
+            BLOCK_N: tl.constexpr,
+        ):
+            row = tl.program_id(0)
+            offsets = tl.arange(0, BLOCK_N)
+            mask = offsets < n_cols
+            values = tl.load(in_ptr + row * stride_b + offsets, mask=mask, other=0.0)
+            tl.store(out_ptr + row * stride_b + offsets, values + 1.0, mask=mask)
+
+        def triton_update(x):
+            out = x
+            add_one_strided_kernel[(x.size(0),)](
+                x,
+                out,
+                x.size(1),
+                x.stride(0),
+                BLOCK_N=4096,
+            )
+            return out
+
+        def f(base):
+            x = (base + 1)[:, :4096]
+            return triton_update(x)
+
+        base = torch.randn(64, 8192, device=GPU_TYPE)
+        eager_out = f(base.clone())
+        compiled_out = torch.compile(f, fullgraph=True)(base.clone())
+
+        self.assertEqual(compiled_out, eager_out)
+        self.assertEqual(compiled_out.stride(), eager_out.stride())
+
+    @requires_gpu
+    def test_triton_kernel_mutates_expanded_intermediate_errors(self):
+        @triton.jit
+        def add_one_expanded_kernel(
+            in_ptr,
+            out_ptr,
+            n_elements: tl.constexpr,
+            stride_n: tl.constexpr,
+            BLOCK_N: tl.constexpr,
+        ):
+            offsets = tl.arange(0, BLOCK_N)
+            mask = offsets < n_elements
+            value = tl.load(in_ptr)
+            tl.store(out_ptr + offsets * stride_n, value + 1.0, mask=mask)
+
+        def triton_update(x):
+            out = x
+            add_one_expanded_kernel[(1,)](
+                x,
+                out,
+                x.numel(),
+                x.stride(0),
+                BLOCK_N=16,
+            )
+            return out
+
+        def f(base):
+            x = (base + 1).expand(4)
+            return triton_update(x)
+
+        base = torch.randn(1, device=GPU_TYPE)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Cannot safely clone an internally overlapping mutated Triton kernel "
+            "argument.",
+        ):
+            torch.compile(f, fullgraph=True)(base.clone())
 
     @inductor_config.patch(
         triton_kernel_default_layout_constraint="needs_fixed_stride_order"

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -11,18 +11,19 @@ import threading
 import typing
 from collections import defaultdict
 from collections.abc import Callable, Sequence
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, cast, Optional, TYPE_CHECKING, Union
 from typing_extensions import Never
 
 import sympy
 
+import torch
 import torch.fx as fx
 import torch.utils._pytree as pytree
 from torch import SymInt, Tensor
 from torch._C import DispatchKey
 from torch._higher_order_ops.utils import redirect_to_mode
 from torch._ops import HigherOrderOperator
-from torch._prims_common import clone_preserve_strides
+from torch._prims_common import compute_required_storage_length
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
@@ -199,6 +200,23 @@ class KernelSideTable:
 
 
 kernel_side_table = KernelSideTable()
+
+
+def clone_preserve_strides_for_triton_kernel_wrapper(x: Tensor) -> Tensor:
+    storage_offset = cast(int, x.storage_offset())
+    needed_size = compute_required_storage_length(x.size(), x.stride(), storage_offset)
+    if torch._debug_has_internal_overlap(x) == 1:
+        raise RuntimeError(
+            "Cannot safely clone an internally overlapping mutated Triton kernel "
+            "argument."
+        )
+    buffer = torch.empty_strided((needed_size,), (1,), dtype=x.dtype, device=x.device)
+    out = torch.as_strided(buffer, x.size(), x.stride(), storage_offset)
+    # Copy logical elements only. Inductor may use a compact internal
+    # materialization for strided views, so flattening the source storage span
+    # can read past the realized buffer.
+    out.copy_(x)
+    return out
 
 
 ###############################################################################
@@ -1546,11 +1564,15 @@ def triton_kernel_wrapper_functional_dense(
     tensors_to_clone: list[str],
 ) -> dict[str, Any]:
     # TODO(oulgen): For performance reasons, we want to ensure that these
-    # `clone_preserve_strides` calls are never executed at runtime
+    # strided clone calls are never executed at runtime
     # (inductor should always optimize them away).
     # Requires https://github.com/pytorch/pytorch/issues/109240
     kwargs = {
-        key: (clone_preserve_strides(val) if key in tensors_to_clone else val)
+        key: (
+            clone_preserve_strides_for_triton_kernel_wrapper(val)
+            if key in tensors_to_clone
+            else val
+        )
         for key, val in kwargs.items()
     }
     triton_kernel_wrapper_mutation(
@@ -1575,12 +1597,12 @@ def triton_kernel_wrapper_functional_fake_tensor_mode(
     tensors_to_clone: list[str],
 ) -> dict[str, Any]:
     # TODO(oulgen): For performance reasons, we want to ensure that these
-    # `clone_preserve_strides` calls are never executed at runtime
+    # strided clone calls are never executed at runtime
     # (inductor should always optimize them away).
     # Requires https://github.com/pytorch/pytorch/issues/109240
     with mode:
         return {
-            key: clone_preserve_strides(val)
+            key: clone_preserve_strides_for_triton_kernel_wrapper(val)
             for key, val in kwargs.items()
             if key in tensors_to_clone
         }


### PR DESCRIPTION
## [cuda_xpu_alignment] Fix Triton HOP clone for strided mutated views (#184050)

Fixes https://github.com/intel-sandbox/agentic_xpu/issues/5

**Root Cause:** In `torch/_higher_order_ops/triton_kernel_wrap.py`, the `triton_kernel_wrapper_functional_dense` and `triton_kernel_wrapper_functional_fake_tensor_mode` functions use `clone_preserve_strides` to clone mutated Triton kernel arguments. For strided views (e.g., `x[::2]`), `clone_preserve_strides` copies the full storage span, which can read past the bounds of compact Inductor temporaries, producing incorrect values. The upstream fix (commit 9a8a62cf0b5) replaces this with a new `clone_preserve_strides_for_triton_kernel_wrapper` that allocates stride-compatible storage and copies only logical elements via `out.copy_(x)`.



---

**Diff stat:**
```
test/inductor/test_triton_kernels.py          | 80 ++++++++++++++++++++++++++-
 torch/_higher_order_ops/triton_kernel_wrap.py | 34 ++++++++++--
 2 files changed, 106 insertions(+), 8 deletions(-)
```


