### PR TITLE
[cuda_xpu_alignment] Fix addmv decomposition dtype validation

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1665,8 +1665,21 @@ def _addmm_activation(
 
 @register_decomposition(aten.addmv)
 @out_wrapper(exact_dtype=True)
-@pw_cast_for_opmath
 def addmv(self: Tensor, mat1: Tensor, vec: Tensor, beta: int = 1, alpha: int = 1):
+    torch._check(
+        self.dtype == mat1.dtype and mat1.dtype == vec.dtype,
+        lambda: (
+            f"addmv input tensors must have the same dtype, but got "
+            f"{self.dtype}, {mat1.dtype}, and {vec.dtype}"
+        ),
+    )
+    return _addmv_impl(self, mat1, vec, beta, alpha)
+
+
+@pw_cast_for_opmath
+def _addmv_impl(
+    self: Tensor, mat1: Tensor, vec: Tensor, beta: int = 1, alpha: int = 1
+):
     if not self.is_floating_point() and not self.is_complex():
         beta = int(beta)
         alpha = int(alpha)


### PR DESCRIPTION
## [cuda_xpu_alignment] Fix addmv decomposition dtype validation

Fixes https://github.com/intel-sandbox/agentic_xpu/issues/4

**Root Cause:** torch/_decomp/decompositions.py:1666-1678 defines the addmv decomposition with @pw_cast_for_opmath, which promotes self/mat1/vec to a common opmath dtype before the function body executes. This bypasses the dtype-equality check enforced by eager's C++ aten::addmv kernel (which raises 'addmv input tensors must have the same dtype'). As a result, torch.compile silently accepts mixed-dtype inputs (e.g., float16 self + float32 mat/vec) that eager correctly rejects, producing divergent eager-vs-compiled behavior.



---

**Diff stat:**
```
torch/_decomp/decompositions.py | 15 ++++++++++++++-
 1 file changed, 14 insertions(+), 1 deletion(-)
```


