### PR TITLE
[cuda_xpu_alignment] DISABLED test_torch_profiler_benchmarker_reuses_inductor_helpers_hip_value0_expected_buffer_size_bytes_1024 (__main__.TestBenchmarker)

### DIFF
--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -142,34 +142,19 @@ on:
       test-matrix:
         value: ${{ jobs.build.outputs.test-matrix || jobs.build-osdc.outputs.test-matrix }}
         description: An optional JSON description of what test configs to run later on.
-      # Separate output for the OSDC-remapped test matrix so shadow-mode test
-      # invocations (issue #183242) can route the OSDC test job to the right
-      # runners while the EC2 test job uses the prefix-stripped matrix above.
-      test-matrix-osdc:
-        value: ${{ jobs.build-osdc.outputs.test-matrix || jobs.build.outputs.test-matrix }}
-        description: An optional JSON description of what test configs to run on OSDC runners.
       build-environment:
         value: ${{ jobs.build.outputs.build-environment || jobs.build-osdc.outputs.build-environment }}
         description: Top-level label for what's being built/tested.
 
 jobs:
   build:
-    # Don't run on forked repos.
-    # Experiment (https://github.com/pytorch/pytorch/issues/183242): always run
-    # the EC2 route on pull_request events and on ciflow/* tag pushes so that
-    # callers passing use-arc=true execute OSDC in shadow mode alongside EC2.
-    # Direct pushes to main/release branches and scheduled workflows continue
-    # to honor use-arc as usual (exactly one route).
-    if: github.repository_owner == 'pytorch' && (!inputs.use-arc || github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/ciflow/'))
-    # Skip runner_prefix on the EC2 route during the OSDC shadow-mode
-    # experiment: the prefix (e.g. mt-) is meant for OSDC runner labels and
-    # would turn an EC2 label like linux.c7i.2xlarge into mt-linux.c7i.2xlarge,
-    # which is not a valid EC2 runner. Revert this once the experiment ends.
-    runs-on: ${{ inputs.runner }}
+    # Don't run on forked repos
+    if: github.repository_owner == 'pytorch' && !inputs.use-arc
+    runs-on: ${{ inputs.runner_prefix }}${{ inputs.runner }}
     timeout-minutes: 480
     outputs:
       docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
-      test-matrix: ${{ steps.strip-runner-prefix.outputs.test-matrix }}
+      test-matrix: ${{ steps.filter.outputs.test-matrix }}
       build-environment: ${{ inputs.build-environment }}
     steps:
       - name: Setup SSH (Click me for login details)
@@ -240,27 +225,6 @@ jobs:
           test-matrix: ${{ inputs.test-matrix }}
           selected-test-configs: ${{ inputs.selected-test-configs }}
           job-name: ${{ steps.setup-linux.outputs.job-name }}
-
-      # Strip the runner_prefix (e.g. mt-) from runner labels in the test matrix
-      # so EC2 test jobs queue against linux.* labels rather than mt-linux.*.
-      # This is needed during the OSDC shadow-mode experiment (issue #183242)
-      # because callers set runner_prefix to the OSDC prefix even when EC2 also
-      # runs. Revert with the rest of the experiment changes.
-      - name: Strip runner prefix from EC2 test matrix
-        id: strip-runner-prefix
-        env:
-          FILTERED_TEST_MATRIX: ${{ steps.filter.outputs.test-matrix }}
-          RUNNER_PREFIX: ${{ inputs.runner_prefix }}
-        shell: bash
-        run: |
-          if [[ -z "${FILTERED_TEST_MATRIX}" || -z "${RUNNER_PREFIX}" ]]; then
-            echo "test-matrix=${FILTERED_TEST_MATRIX}" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-          stripped=$(jq -c --arg p "${RUNNER_PREFIX}" '
-            if .include then .include |= map(.runner |= ltrimstr($p)) else . end
-          ' <<< "${FILTERED_TEST_MATRIX}")
-          echo "test-matrix=${stripped}" >> "${GITHUB_OUTPUT}"
 
       - name: Start monitoring script
         id: monitor-script

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -11,14 +11,6 @@ on:
         required: true
         type: string
         description: JSON description of what test configs to run.
-      test-matrix-osdc:
-        required: false
-        type: string
-        default: ""
-        description: |
-          OSDC-remapped test matrix used by the test-osdc job during the
-          shadow-mode experiment (issue #183242). Falls back to test-matrix
-          when empty so OSDC-only callers keep working unchanged.
       docker-image:
         required: true
         type: string
@@ -131,13 +123,8 @@ env:
 
 jobs:
   test:
-    # Don't run on forked repos or empty test matrix.
-    # Experiment (https://github.com/pytorch/pytorch/issues/183242): always run
-    # the EC2 route on pull_request events and on ciflow/* tag pushes so that
-    # callers passing use-arc=true execute OSDC in shadow mode alongside EC2.
-    # Direct pushes to main/release branches and scheduled workflows continue
-    # to honor use-arc as usual (exactly one route).
-    if: github.repository_owner == 'pytorch' && toJSON(fromJSON(inputs.test-matrix).include) != '[]' && (!inputs.use-arc || github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/ciflow/'))
+    # Don't run on forked repos or empty test matrix
+    if: github.repository_owner == 'pytorch' && toJSON(fromJSON(inputs.test-matrix).include) != '[]' && !inputs.use-arc
     strategy:
       matrix: ${{ fromJSON(inputs.test-matrix) }}
       fail-fast: false
@@ -621,13 +608,10 @@ jobs:
           docker kill -a || true
 
   test-osdc:
-    # Don't run on forked repos or empty test matrix.
-    # During the OSDC shadow-mode experiment (issue #183242) the build workflow
-    # emits a separate test-matrix-osdc with OSDC-remapped runners; fall back to
-    # test-matrix when callers haven't been updated yet.
-    if: github.repository_owner == 'pytorch' && toJSON(fromJSON(inputs.test-matrix-osdc != '' && inputs.test-matrix-osdc || inputs.test-matrix).include) != '[]' && inputs.use-arc
+    # Don't run on forked repos or empty test matrix
+    if: github.repository_owner == 'pytorch' && toJSON(fromJSON(inputs.test-matrix).include) != '[]' && inputs.use-arc
     strategy:
-      matrix: ${{ fromJSON(inputs.test-matrix-osdc != '' && inputs.test-matrix-osdc || inputs.test-matrix) }}
+      matrix: ${{ fromJSON(inputs.test-matrix) }}
       fail-fast: false
     environment: ${{ github.ref == 'refs/heads/main' && 'scribe-protected' || startsWith(github.ref, 'refs/heads/release/') && 'scribe-protected' || contains(github.event.pull_request.labels.*.name, 'ci-scribe') && 'scribe-pr' || '' }}
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/attention_op_microbenchmark.yml
+++ b/.github/workflows/attention_op_microbenchmark.yml
@@ -63,7 +63,6 @@ jobs:
       build-environment: ${{ needs.attn-microbenchmark-build.outputs.build-environment }}
       docker-image: ${{ needs.attn-microbenchmark-build.outputs.docker-image }}
       test-matrix: ${{ needs.attn-microbenchmark-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.attn-microbenchmark-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11
@@ -104,7 +103,6 @@ jobs:
       build-environment: ${{ needs.opmicrobenchmark-build-b200.outputs.build-environment }}
       docker-image: ${{ needs.opmicrobenchmark-build-b200.outputs.docker-image }}
       test-matrix: ${{ needs.opmicrobenchmark-build-b200.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.opmicrobenchmark-build-b200.outputs.test-matrix-osdc }}
       use-arc: true
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/dtensor.yml
+++ b/.github/workflows/dtensor.yml
@@ -60,7 +60,6 @@ jobs:
       build-environment: linux-jammy-cuda13.0-py3.10-gcc11
       docker-image: ${{ needs.dtensor-build.outputs.docker-image }}
       test-matrix: ${{ needs.dtensor-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.dtensor-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/dynamo-unittest.yml
+++ b/.github/workflows/dynamo-unittest.yml
@@ -71,7 +71,6 @@ jobs:
       build-environment: linux-jammy-py${{ matrix.python-version }}-clang18
       docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-py${{ matrix.python-version }}-clang18-${{ needs.get-label-type.outputs.ci-docker-hash }}
       test-matrix: ${{ needs.dynamo-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.dynamo-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: ${{ matrix.python-version }}
       compiler: clang18

--- a/.github/workflows/h100-cutlass-backend.yml
+++ b/.github/workflows/h100-cutlass-backend.yml
@@ -66,7 +66,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-cutlass-backend.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-cutlass-backend.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-cutlass-backend.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-cutlass-backend.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/h100-symm-mem.yml
+++ b/.github/workflows/h100-symm-mem.yml
@@ -63,7 +63,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-symm.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-symm.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-symm.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-symm.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/inductor-micro-benchmark-x86.yml
+++ b/.github/workflows/inductor-micro-benchmark-x86.yml
@@ -61,7 +61,6 @@ jobs:
       build-environment: ${{ needs.inductor-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.inductor-build.outputs.test-matrix-osdc }}
       timeout-minutes: 720
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"

--- a/.github/workflows/inductor-micro-benchmark.yml
+++ b/.github/workflows/inductor-micro-benchmark.yml
@@ -62,7 +62,6 @@ jobs:
       build-environment: ${{ needs.build.outputs.build-environment }}
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.build.outputs.test-matrix-osdc }}
       timeout-minutes: 720
       use-arc: ${{ needs.get-default-label-prefix.outputs.use-arc == 'true' }}
       python-version: "3.10"

--- a/.github/workflows/inductor-nightly.yml
+++ b/.github/workflows/inductor-nightly.yml
@@ -68,7 +68,6 @@ jobs:
       build-environment: ${{ needs.nightly-dynamo-benchmarks-build.outputs.build-environment }}
       docker-image: ${{ needs.nightly-dynamo-benchmarks-build.outputs.docker-image }}
       test-matrix: ${{ needs.nightly-dynamo-benchmarks-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.nightly-dynamo-benchmarks-build.outputs.test-matrix-osdc }}
       timeout-minutes: 720
       use-arc: ${{ needs.get-default-label-prefix.outputs.use-arc == 'true' }}
       python-version: "3.10"

--- a/.github/workflows/inductor-perf-compare.yml
+++ b/.github/workflows/inductor-perf-compare.yml
@@ -64,7 +64,6 @@ jobs:
       build-environment: ${{ needs.build.outputs.build-environment }}
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.build.outputs.test-matrix-osdc }}
       # disable monitor in perf tests for more investigation
       disable-monitor: false
       monitor-log-interval: 15

--- a/.github/workflows/inductor-perf-test-nightly-h100.yml
+++ b/.github/workflows/inductor-perf-test-nightly-h100.yml
@@ -153,7 +153,6 @@ jobs:
       dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true-deterministic_perf-true
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.build.outputs.test-matrix-osdc }}
       timeout-minutes: 720
       # disable monitor in perf tests, next step is to enable it
       disable-monitor: false
@@ -179,7 +178,6 @@ jobs:
       dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true-maxautotune-true-freeze_autotune_cudagraphs-true-deterministic_perf-true
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.build.outputs.test-matrix-osdc }}
       timeout-minutes: 1440
       # disable monitor in perf tests, next step is to enable it
       disable-monitor: false
@@ -207,7 +205,6 @@ jobs:
       dashboard-tag: training-${{ inputs.training || 'true' }}-inference-${{ inputs.inference || 'true' }}-default-${{ inputs.default || 'true' }}-dynamic-${{ inputs.dynamic || 'true' }}-cudagraphs-${{ inputs.cudagraphs || 'true' }}-cppwrapper-${{ inputs.cppwrapper || 'false' }}-aotinductor-${{ inputs.aotinductor || 'false' }}-maxautotune-${{ inputs.maxautotune || 'false' }}-freezing_cudagraphs-${{ inputs.freezing_cudagraphs || 'false' }}-deterministic_perf-${{ inputs.deterministic_perf || 'false' }}-batch_invariant_accuracy-${{ inputs.batch_invariant_accuracy || 'false' }}
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.build.outputs.test-matrix-osdc }}
       timeout-minutes: 720
       # disable monitor in perf tests for more investigation
       disable-monitor: false

--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -133,7 +133,6 @@ jobs:
       dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.build.outputs.test-matrix-osdc }}
       timeout-minutes: 720
       disable-monitor: false
       monitor-log-interval: 15
@@ -158,7 +157,6 @@ jobs:
       dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true-maxautotune-true-freeze_autotune_cudagraphs-true
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.build.outputs.test-matrix-osdc }}
       timeout-minutes: 1440
       # disable monitor in perf tests, next step is to enable it
       disable-monitor: false
@@ -184,7 +182,6 @@ jobs:
       dashboard-tag: training-${{ inputs.training }}-inference-${{ inputs.inference }}-default-${{ inputs.default }}-dynamic-${{ inputs.dynamic }}-cudagraphs-${{ inputs.cudagraphs }}-cppwrapper-${{ inputs.cppwrapper }}-aotinductor-${{ inputs.aotinductor }}-maxautotune-${{ inputs.maxautotune }}-freezing_cudagraphs-${{ inputs.freezing_cudagraphs }}
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.build.outputs.test-matrix-osdc }}
       timeout-minutes: 720
       disable-monitor: false
       monitor-log-interval: 15

--- a/.github/workflows/inductor-periodic.yml
+++ b/.github/workflows/inductor-periodic.yml
@@ -92,7 +92,6 @@ jobs:
       build-environment: ${{ needs.periodic-dynamo-benchmarks-build.outputs.build-environment }}
       docker-image: ${{ needs.periodic-dynamo-benchmarks-build.outputs.docker-image }}
       test-matrix: ${{ needs.periodic-dynamo-benchmarks-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.periodic-dynamo-benchmarks-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-default-label-prefix.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11
@@ -179,7 +178,6 @@ jobs:
       build-environment: ${{ needs.inductor-smoke-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-smoke-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-smoke-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.inductor-smoke-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-default-label-prefix.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11
@@ -252,7 +250,6 @@ jobs:
       build-environment: ${{ needs.periodic-dynamo-benchmarks-cpu-build.outputs.build-environment }}
       docker-image: ${{ needs.periodic-dynamo-benchmarks-cpu-build.outputs.docker-image }}
       test-matrix: ${{ needs.periodic-dynamo-benchmarks-cpu-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.periodic-dynamo-benchmarks-cpu-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-default-label-prefix.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -67,7 +67,6 @@ jobs:
       build-environment: ${{ needs.inductor-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.inductor-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11
@@ -102,7 +101,6 @@ jobs:
       build-environment: ${{ needs.inductor-halide-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-halide-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-halide-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.inductor-halide-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.12"
       compiler: gcc11
@@ -136,7 +134,6 @@ jobs:
       build-environment: ${{ needs.inductor-pallas-cpu-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-pallas-cpu-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-pallas-cpu-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.inductor-pallas-cpu-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.12"
       compiler: gcc11
@@ -170,7 +167,6 @@ jobs:
       build-environment: ${{ needs.inductor-triton-cpu-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-triton-cpu-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-triton-cpu-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.inductor-triton-cpu-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.12"
       compiler: gcc11
@@ -205,7 +201,6 @@ jobs:
       build-environment: ${{ needs.inductor-cpu-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-cpu-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-cpu-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.inductor-cpu-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11
@@ -244,7 +239,6 @@ jobs:
       build-environment: linux-jammy-py${{ matrix.python-version }}-clang18
       docker-image: ${{ needs.get-label-type.outputs.use-arc == 'true' && 'ghcr.io/pytorch/' || '' }}ci-image:pytorch-linux-jammy-py${{ matrix.python-version }}-clang18
       test-matrix: ${{ needs.inductor-cpu-core-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.inductor-cpu-core-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "${{ matrix.python-version }}"
       compiler: clang18

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -82,7 +82,6 @@ jobs:
       build-environment: ${{ needs.inductor-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.inductor-build.outputs.test-matrix-osdc }}
       enable-torch-trace: "1"
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
@@ -125,7 +124,6 @@ jobs:
       build-environment: ${{ needs.inductor-cpu-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-cpu-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-cpu-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.inductor-cpu-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/operator_benchmark.yml
+++ b/.github/workflows/operator_benchmark.yml
@@ -72,7 +72,6 @@ jobs:
       build-environment: ${{ needs.x86-opbenchmark-build.outputs.build-environment }}
       docker-image: ${{ needs.x86-opbenchmark-build.outputs.docker-image }}
       test-matrix: ${{ needs.x86-opbenchmark-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.x86-opbenchmark-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11
@@ -110,7 +109,6 @@ jobs:
       build-environment: ${{ needs.aarch64-opbenchmark-build.outputs.build-environment }}
       docker-image: ${{ needs.aarch64-opbenchmark-build.outputs.docker-image }}
       test-matrix: ${{ needs.aarch64-opbenchmark-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.aarch64-opbenchmark-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc13

--- a/.github/workflows/operator_microbenchmark.yml
+++ b/.github/workflows/operator_microbenchmark.yml
@@ -66,7 +66,6 @@ jobs:
       build-environment: ${{ needs.opmicrobenchmark-build.outputs.build-environment }}
       docker-image: ${{ needs.opmicrobenchmark-build.outputs.docker-image }}
       test-matrix: ${{ needs.opmicrobenchmark-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.opmicrobenchmark-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11
@@ -107,7 +106,6 @@ jobs:
       build-environment: ${{ needs.opmicrobenchmark-build-b200.outputs.build-environment }}
       docker-image: ${{ needs.opmicrobenchmark-build-b200.outputs.docker-image }}
       test-matrix: ${{ needs.opmicrobenchmark-build-b200.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.opmicrobenchmark-build-b200.outputs.test-matrix-osdc }}
       use-arc: true
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/operator_microbenchmark_compare.yml
+++ b/.github/workflows/operator_microbenchmark_compare.yml
@@ -75,7 +75,6 @@ jobs:
       build-environment: ${{ needs.build-cuda.outputs.build-environment }}
       docker-image: ${{ needs.build-cuda.outputs.docker-image }}
       test-matrix: ${{ needs.build-cuda.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.build-cuda.outputs.test-matrix-osdc }}
     secrets: inherit
 
   # ---- CUDA build for B200 (sm100) ----
@@ -114,7 +113,6 @@ jobs:
       build-environment: ${{ needs.build-b200.outputs.build-environment }}
       docker-image: ${{ needs.build-b200.outputs.docker-image }}
       test-matrix: ${{ needs.build-b200.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.build-b200.outputs.test-matrix-osdc }}
       use-arc: true
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -93,7 +93,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11
@@ -137,7 +136,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-debug-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-debug-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-debug-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-debug-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11
@@ -182,7 +180,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3-gcc11-slow-gradcheck-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3-gcc11-slow-gradcheck-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3-gcc11-slow-gradcheck-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-cuda13_0-py3-gcc11-slow-gradcheck-build.outputs.test-matrix-osdc }}
       timeout-minutes: 300
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -117,7 +117,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.test-matrix-osdc }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
@@ -165,7 +164,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.test-matrix-osdc }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
@@ -217,7 +215,6 @@ jobs:
       build-environment: linux-jammy-py3.14t-clang18
       docker-image: ${{ needs.linux-jammy-py3_14t-clang18-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_14t-clang18-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-py3_14t-clang18-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.14t"
       compiler: clang18
@@ -318,7 +315,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.test-matrix-osdc }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
@@ -377,7 +373,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.test-matrix-osdc }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
@@ -432,7 +427,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-py3_14-clang18-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3_14-clang18-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_14-clang18-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-py3_14-clang18-build.outputs.test-matrix-osdc }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.14"
@@ -572,7 +566,6 @@ jobs:
       build-environment: linux-jammy-py3.13-clang18
       docker-image: ${{ needs.dynamo-cpython-build.outputs.docker-image }}
       test-matrix: ${{ needs.dynamo-cpython-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.dynamo-cpython-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.13"
       compiler: clang18

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -78,7 +78,6 @@ jobs:
       build-environment: linux-jammy-cuda13.0-py3.10-gcc11-sm86
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm86-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm86-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm86-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11
@@ -115,7 +114,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: clang18
@@ -154,7 +152,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.test-matrix-osdc }}
       sync-tag: asan-test
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"

--- a/.github/workflows/test-b200.yml
+++ b/.github/workflows/test-b200.yml
@@ -82,7 +82,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm100-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm100-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm100-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm100-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/test-h100.yml
+++ b/.github/workflows/test-h100.yml
@@ -67,7 +67,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/torchtitan.yml
+++ b/.github/workflows/torchtitan.yml
@@ -64,7 +64,6 @@ jobs:
       build-environment: linux-jammy-cuda13.0-py3-gcc11
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -134,7 +134,6 @@ jobs:
       build-environment: linux-jammy-cuda13.0-py3.10-gcc11
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.test-matrix-osdc }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
@@ -360,7 +359,6 @@ jobs:
       build-environment: ${{ needs.verify-cachebench-cpu-build.outputs.build-environment }}
       docker-image: ${{ needs.verify-cachebench-cpu-build.outputs.docker-image }}
       test-matrix: ${{ needs.verify-cachebench-cpu-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.verify-cachebench-cpu-build.outputs.test-matrix-osdc }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
@@ -398,7 +396,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-py3-clang18-executorch-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3-clang18-executorch-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3-clang18-executorch-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-py3-clang18-executorch-build.outputs.test-matrix-osdc }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
     secrets: inherit
 
@@ -454,7 +451,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc13

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -55,7 +55,6 @@ jobs:
       build-environment: linux-jammy-py3.14t-clang18-tsan
       docker-image: ${{ needs.linux-jammy-py3_14t-clang18-tsan-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_14t-clang18-tsan-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-py3_14t-clang18-tsan-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.14t"
       compiler: clang18

--- a/aten/src/ATen/native/NaiveDilatedConvolution.cpp
+++ b/aten/src/ATen/native/NaiveDilatedConvolution.cpp
@@ -612,7 +612,7 @@ Tensor slow_conv_dilated3d_cpu(
   Tensor output_ = (is_batch ? output : output.unsqueeze(0));
 
   slow_conv_dilated_all_cpu_template<3>(
-      output,
+      output_,
       input_,
       weight_,
       bias_,

--- a/aten/src/ATen/native/cuda/NaiveDilatedConvolution.cu
+++ b/aten/src/ATen/native/cuda/NaiveDilatedConvolution.cu
@@ -538,7 +538,7 @@ Tensor slow_conv_dilated3d_cuda(
   Tensor output_ = (is_batch ? output : output.unsqueeze(0));
 
   slow_conv_dilated_all_cuda_template<3>(
-      output,
+      output_,
       input_,
       weight_,
       bias_,

--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -57,22 +57,6 @@ torch.backends.cuda.matmul.allow_tf32 = False
 device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
 
-def gpus_for_rank(world_size):
-    """Multigpu tests are designed to simulate the multi nodes with multi
-    GPUs on each node. Nccl backend requires equal #GPUs in each process.
-    On a single node, all visible GPUs are evenly
-    divided to subsets, each process only uses a subset.
-    """
-    visible_devices = list(range(torch.accelerator.device_count()))
-    gpus_per_process = torch.accelerator.device_count() // world_size
-    gpus_for_rank = []
-    for rank in range(world_size):
-        gpus_for_rank.append(
-            visible_devices[rank * gpus_per_process : (rank + 1) * gpus_per_process]
-        )
-    return gpus_for_rank
-
-
 class StoreTestBase:
     def _create_store(self, i):
         raise RuntimeError("not implemented")

--- a/test/dynamo/_test_compiler_bisector_run_helper.py
+++ b/test/dynamo/_test_compiler_bisector_run_helper.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 
 import torch
 import torch._prims_common as utils
+from torch.testing._internal.inductor_utils import GPU_TYPE
 
 
 aten = torch.ops.aten
@@ -48,7 +49,7 @@ def vq(x):
 def test_fn():
     with patch_exp_decomp():
         vq_compiled = torch.compile(vq)
-        x = torch.randn(4, 400, 256).cuda()
+        x = torch.randn(4, 400, 256, device=GPU_TYPE)
         out_compiled = vq_compiled(x)
 
     return 1 if out_compiled.isnan().any() else 0

--- a/test/dynamo/test_compiler_bisector.py
+++ b/test/dynamo/test_compiler_bisector.py
@@ -12,7 +12,8 @@ from torch._inductor.compiler_bisector import CompilerBisector
 from torch._inductor.custom_graph_pass import CustomGraphPass
 from torch._inductor.test_case import TestCase
 from torch.library import _scoped_library, Library
-from torch.testing._internal.inductor_utils import HAS_GPU
+from torch.testing._internal.common_utils import requires_cuda
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
 aten = torch.ops.aten
@@ -84,7 +85,7 @@ class TestCompilerBisector(TestCase):
             torch._dynamo.reset()
             with patch_exp_decomp():
                 vq_compiled = torch.compile(vq)
-                x = torch.randn(4, 400, 256).cuda()
+                x = torch.randn(4, 400, 256, device=GPU_TYPE)
                 with torch._dynamo.utils.preserve_rng_state():
                     vq(x)
                 out_compiled = vq_compiled(x)
@@ -158,7 +159,7 @@ class TestCompilerBisector(TestCase):
         def test_fn():
             torch._dynamo.reset()
 
-            inp = torch.rand([10], device="cuda")
+            inp = torch.rand([10], device=GPU_TYPE)
 
             out = foo(inp)
             out_c = torch.compile(foo)(inp)
@@ -174,7 +175,7 @@ class TestCompilerBisector(TestCase):
 
     def test_rng(self):
         def foo():
-            return torch.rand([10], device="cuda") + 1
+            return torch.rand([10], device=GPU_TYPE) + 1
 
         def test_fn():
             torch._dynamo.reset()
@@ -248,7 +249,7 @@ class TestCompilerBisector(TestCase):
 
             dtype = torch.bfloat16
             torch.manual_seed(0)
-            inp = torch.randn(16, 16, 768, dtype=dtype, device="cuda")
+            inp = torch.randn(16, 16, 768, dtype=dtype, device=GPU_TYPE)
             eager_scale = calculate_scale(inp)
             compile_scale = torch.compile(calculate_scale)(inp)
 
@@ -266,7 +267,7 @@ class TestCompilerBisector(TestCase):
                 def my_func(x):
                     return ((x * -1) - 0.01).relu()
 
-                inp = torch.rand([100], device="cuda")
+                inp = torch.rand([100], device=GPU_TYPE)
 
                 return torch.allclose(torch.compile(my_func)(inp), my_func(inp))
 
@@ -328,7 +329,7 @@ class TestCompilerBisector(TestCase):
         def test_fn():
             torch._dynamo.reset()
 
-            x = torch.randn(1024, device="cuda")
+            x = torch.randn(1024, device=GPU_TYPE)
             with config.patch("triton.inject_relu_bug_TESTING_ONLY", "accuracy"):
                 opt_f = torch.compile(f, backend=MyBackend())
                 return torch.allclose(opt_f(x), f(x))
@@ -338,6 +339,7 @@ class TestCompilerBisector(TestCase):
         self.assertEqual(out.subsystem, "pre_grad_graph")
         self.assertEqual(out.bisect_number, 1)
 
+    @requires_cuda
     def test_cudagraph_bisect_max(self):
         """Test that cudagraph bisector can limit number of cudagraphed graphs."""
         import os
@@ -367,7 +369,7 @@ class TestCompilerBisector(TestCase):
             try:
                 foo_c = torch.compile(foo, mode="reduce-overhead")
                 bar_c = torch.compile(bar, mode="reduce-overhead")
-                x = torch.randn(10, device="cuda")
+                x = torch.randn(10, device=GPU_TYPE)
                 foo_c(x)
                 bar_c(x)
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -2920,8 +2920,8 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
             self.assertExpectedInline(cnts.frame_count, """0""")
             self.assertExpectedInline(cnts.op_count, """0""")
         else:
-            self.assertExpectedInline(cnts.frame_count, """1""")
-            self.assertExpectedInline(cnts.op_count, """2""")
+            self.assertExpectedInline(cnts.frame_count, """0""")
+            self.assertExpectedInline(cnts.op_count, """0""")
 
     def test_list_slice_mul(self):
         def fn(count):
@@ -2936,8 +2936,8 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
             self.assertExpectedInline(cnts.frame_count, """0""")
             self.assertExpectedInline(cnts.op_count, """0""")
         else:
-            self.assertExpectedInline(cnts.frame_count, """1""")
-            self.assertExpectedInline(cnts.op_count, """2""")
+            self.assertExpectedInline(cnts.frame_count, """0""")
+            self.assertExpectedInline(cnts.op_count, """0""")
 
     def test_tuple_mul(self):
         def fn(count):
@@ -2951,8 +2951,8 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
             self.assertExpectedInline(cnts.frame_count, """0""")
             self.assertExpectedInline(cnts.op_count, """0""")
         else:
-            self.assertExpectedInline(cnts.frame_count, """1""")
-            self.assertExpectedInline(cnts.op_count, """2""")
+            self.assertExpectedInline(cnts.frame_count, """0""")
+            self.assertExpectedInline(cnts.op_count, """0""")
 
     def test_tuple_mul_with_shape(self):
         def fn(a):

--- a/test/dynamo/test_nb_multiply.py
+++ b/test/dynamo/test_nb_multiply.py
@@ -512,6 +512,54 @@ class TestNbMultiply(torch._dynamo.test_case.TestCase):
         self.assertEqual(f(2, 3), [2, 2, 2])
         self.assertEqual(f(2, True), [2])
 
+    # --- Sequence * SymNode must route through sq_repeat, not nb_multiply ---
+
+    def test_list_mul_symint_iter(self):
+        @torch.compile(backend="eager", fullgraph=True, dynamic=True)
+        def f(t):
+            return list([1, 2] * t.shape[0])
+
+        self.assertEqual(f(torch.randn(3, 4)), [1, 2, 1, 2, 1, 2])
+
+    def test_symint_mul_list_iter(self):
+        @torch.compile(backend="eager", fullgraph=True, dynamic=True)
+        def f(t):
+            return list(t.shape[0] * [1, 2])
+
+        self.assertEqual(f(torch.randn(3, 4)), [1, 2, 1, 2, 1, 2])
+
+    def test_tuple_mul_symint_iter(self):
+        @torch.compile(backend="eager", fullgraph=True, dynamic=True)
+        def f(t):
+            return list((1, 2) * t.shape[0])
+
+        self.assertEqual(f(torch.randn(3, 4)), [1, 2, 1, 2, 1, 2])
+
+    def test_str_mul_symint_iter(self):
+        @torch.compile(backend="eager", fullgraph=True, dynamic=True)
+        def f(t):
+            return list("ab" * t.shape[0])
+
+        self.assertEqual(f(torch.randn(3, 4)), ["a", "b", "a", "b", "a", "b"])
+
+    def test_list_imul_symint_iter(self):
+        @torch.compile(backend="eager", fullgraph=True, dynamic=True)
+        def f(t):
+            xs = [1, 2]
+            xs *= t.shape[0]
+            return list(xs)
+
+        self.assertEqual(f(torch.randn(3, 4)), [1, 2, 1, 2, 1, 2])
+
+    def test_list_mul_symint_sum(self):
+        # Forces iteration via sum() rather than list() to exercise a
+        # different consumer of the resulting sequence VT.
+        @torch.compile(backend="eager", fullgraph=True, dynamic=True)
+        def f(t):
+            return sum([1, 2] * t.shape[0])
+
+        self.assertEqual(f(torch.randn(3, 4)), 9)
+
     # --- Error message accuracy (matches CPython exactly) ---
 
     @make_dynamo_test

--- a/test/inductor/test_benchmarking.py
+++ b/test/inductor/test_benchmarking.py
@@ -19,7 +19,6 @@ from torch.testing._internal.common_utils import (
     decorateIf,
     instantiate_parametrized_tests,
     parametrize,
-    skipIfXpu,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
 
@@ -226,8 +225,6 @@ class TestBenchmarker(TestCase):
             _bench._BENCHMARK_DISPATCH.clear()
             _bench._BENCHMARK_DISPATCH.update(orig)
 
-    @skipIfXpu(msg="https://github.com/pytorch/pytorch/issues/184491")
-    @skipIfXpu(msg="https://github.com/pytorch/pytorch/issues/184470")
     @unittest.skipIf(not HAS_GPU, "requires GPU")
     @parametrize(
         "hip_value, expected_buffer_size_bytes",

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -598,6 +598,35 @@ class TestConvolutionNN(NNTestCase):
                         (inputs.cpu(), weight.cpu(), bias.cpu()),
                     )
 
+                # Non-batched must match batched-then-squeezed.
+                inputs_nb = inputs[0]
+                with torch.backends.cudnn.flags(enabled=False):
+                    res_nb = convfn(inputs_nb, weight, bias, **kwargs)
+                    res_via_batched = convfn(
+                        inputs_nb.unsqueeze(0), weight, bias, **kwargs
+                    ).squeeze(0)
+                self.assertEqual(res_nb, res_via_batched)
+
+    def test_slow_conv_dilated3d_unbatched(self):
+        # Direct op call to guarantee the slow path.
+        for device in ["cpu"] + (["cuda"] if TEST_CUDA else []):
+            input = torch.randn(2, 5, 5, 5, dtype=torch.double, device=device)
+            weight = torch.randn(3, 2, 3, 3, 3, dtype=torch.double, device=device)
+            bias = torch.randn(3, dtype=torch.double, device=device)
+            kwargs = dict(
+                kernel_size=[3, 3, 3],
+                stride=[1, 1, 1],
+                padding=[0, 0, 0],
+                dilation=[2, 2, 2],
+            )
+            out_nb = torch.ops.aten.slow_conv_dilated3d(
+                input, weight, bias=bias, **kwargs
+            )
+            out_batched = torch.ops.aten.slow_conv_dilated3d(
+                input.unsqueeze(0), weight, bias=bias, **kwargs
+            ).squeeze(0)
+            self.assertEqual(out_nb, out_batched)
+
     def test_Conv2d_inconsistent_types(self):
         inputs = torch.randn(4, 1, 7, 7, dtype=torch.float)
         weights = torch.randn(1, 1, 3, 3, dtype=torch.double)

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -2611,7 +2611,8 @@ class SymNodeVariable(VariableTracker):
         other: VariableTracker,
         reverse: bool = False,
     ) -> VariableTracker:
-        if not other.is_symnode_like() and not other.is_python_constant():
+        # sequence * sym_node must go through sq_repeat and not nb_multiply
+        if not _is_sym_arith_operand(other):
             return VariableTracker.build(tx, NotImplemented)
         lhs, rhs = (other, self) if reverse else (self, other)
         return SymNodeVariable.create(

--- a/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
@@ -34,6 +34,7 @@ from torch._inductor.virtualized import V
 
 from ...utils import sympy_index_symbol
 from .cutedsl_op_overrides import CuteDSLCSEVariable, CuteDSLOpOverrides
+from .lane_analysis import classify_lane_expr
 
 
 # TODO setting the 'main' kernel w/ this suffix. We have 3 should probably just auto generate this
@@ -101,7 +102,8 @@ class CuteDSLIndexFragment:
         code: Python source expression for the index or index fragment.
         is_static_int: True when code is an inline integer index, not a fragment.
         is_lane_uniform: True when every vector lane has the same index.
-        is_contiguous: True when code is lane-contiguous in the vectorized index.
+        is_contiguous: True when code is aligned and contiguous for the full
+            requested vector width.
     """
 
     code: str
@@ -241,6 +243,7 @@ class CuteDSLTemplateKernel(Kernel):
             "gen_defines": lambda: self.gen_defines(**kwargs),
             "get_output": self.get_output,
             "get_tensor_buffers": self.get_tensor_buffers,
+            "add_tensor_inputs": self.add_tensor_inputs,
             "unpack_buffers": self.unpack_buffers,
             "modification": self.modification,
             "set_cute_hash": self.set_cute_hash,
@@ -406,6 +409,19 @@ class CuteDSLTemplateKernel(Kernel):
     def get_tensor_buffers(self):
         """Get list of tensor buffer names that were collected during modifications."""
         return self.collected_tensor_buffers
+
+    def add_tensor_inputs(self, buffers):
+        """Register extra tensor buffers and return their rendered input names."""
+        buffer_names = []
+        for buffer in buffers:
+            if isinstance(buffer, sympy.Expr):
+                # Symbolic size/index expressions are not kernel tensor inputs yet.
+                continue
+            remapped_name = self.args.input(buffer.get_name())
+            if remapped_name not in self.collected_tensor_buffers:
+                self.collected_tensor_buffers.append(remapped_name)
+            buffer_names.append(remapped_name)
+        return buffer_names
 
     def unpack_buffers(self, buffer_list_name: str, *, indent_width: int = 4):
         """Generate buffer unpacking code via render hook."""
@@ -886,20 +902,16 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
         if self.vector_load_config.vec_size <= 1:
             return True, False, None
 
-        lane_contiguity = V.graph.sizevars.analyze_lane_contiguity(
+        lane_info = classify_lane_expr(
             semantic_expr,
             self.vector_load_config.index,
-        )
-        contiguous_width = self._aligned_contiguous_width(
-            semantic_expr,
-            self.vector_load_config.index,
-            lane_contiguity,
-            self.vector_load_config.vec_size,
+            max_width=self.vector_load_config.vec_size,
+            uniform_symbols=self._lane_uniform_symbols(),
         )
         return (
-            self._is_lane_uniform_expr(semantic_expr, self.vector_load_config.index),
-            lane_contiguity.stride == 1 and contiguous_width is not None,
-            contiguous_width,
+            lane_info.is_uniform,
+            lane_info.is_contiguous,
+            lane_info.contiguous_width,
         )
 
     @staticmethod
@@ -932,37 +944,20 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
                 replacements[sympy_index_symbol(var.name)] = var.index_expr
         return V.graph.sizevars.simplify(expr.xreplace(replacements))
 
-    def _is_lane_uniform_expr(
-        self, expr: sympy.Expr, vector_index: sympy.Symbol
-    ) -> bool:
-        """Return true when expr depends only on non-vectorized indices."""
-        allowed_symbols = OrderedSet(
-            sympy_index_symbol(source_expr)
-            for source_expr in self.kernel.cse._cache
-            if isinstance(source_expr, str) and source_expr != vector_index.name
+    def _lane_uniform_symbols(self) -> OrderedSet[sympy.Symbol]:
+        """Return generated CSE source symbols that are uniform across lanes."""
+        vector_index_name = (
+            None
+            if self.vector_load_config is None
+            else self.vector_load_config.index.name
         )
-        return bool(expr.free_symbols and expr.free_symbols <= allowed_symbols)
-
-    @staticmethod
-    def _aligned_contiguous_width(
-        expr: sympy.Expr,
-        vector_index: sympy.Symbol,
-        lane_contiguity,
-        max_width: int,
-    ) -> int | None:
-        """Narrow contiguous width until the first lane is statically aligned."""
-        start_expr = V.graph.sizevars.simplify(
-            expr.xreplace({vector_index: sympy.Integer(0)})
+        return OrderedSet(
+            [
+                sympy_index_symbol(source_expr)
+                for source_expr in self.kernel.cse._cache
+                if isinstance(source_expr, str) and source_expr != vector_index_name
+            ]
         )
-        for width in (max_width, 4, 2):
-            if (
-                width <= max_width
-                and lane_contiguity.is_contiguous_for(width)
-                and V.graph.sizevars.statically_known_multiple_of(start_expr, width)
-                and V.graph.sizevars.statically_known_geq(start_expr, 0)
-            ):
-                return width
-        return None
 
     def indirect_indexing(self, index_var: str, size, check, wrap_neg=True):
         """Convert index variable to symbolic form."""

--- a/torch/_inductor/codegen/cutedsl/lane_analysis.py
+++ b/torch/_inductor/codegen/cutedsl/lane_analysis.py
@@ -1,0 +1,139 @@
+# mypy: allow-untyped-defs
+
+import dataclasses
+
+import sympy
+
+from torch.utils._ordered_set import OrderedSet
+
+from ...virtualized import V
+
+
+@dataclasses.dataclass(frozen=True)
+class LaneExprInfo:
+    """How an index expression changes across vectorized lanes.
+
+    A lane is one element of =a vectorized CuteDSL computation. For a 32-lane
+    mask/load, lane 0 is the first element in the group and lane 31 is the last.
+
+    Attributes:
+        is_uniform: All lanes evaluate to the same value, e.g. for flex-flash``b_idx``.
+        is_contiguous: Lanes evaluate to consecutive aligned values for the
+            requested width, e.g. ``kv_idx + lane`` when lane 0 is aligned.
+        contiguous_width: Largest aligned contiguous power-of-two width proven,
+            or None if no vector-width contiguity is proven.
+    """
+
+    is_uniform: bool
+    is_contiguous: bool
+    contiguous_width: int | None
+
+
+def classify_lane_expr(
+    expr: sympy.Expr,
+    lane_var: sympy.Symbol,
+    *,
+    max_width: int,
+    uniform_symbols: OrderedSet[sympy.Symbol] | None = None,
+) -> LaneExprInfo:
+    """Classify how ``expr`` varies across ``lane_var`` vector lanes.
+
+    ``max_width`` is the requested vector width. We start with this as the
+    maximum width to check and then decrease in powers of two trying to find a width
+    that satisfies contiguity across lanes. We cap since we are trying to get vectorized loads
+    which are at 128 and 256(B200) bits so no need to check higher.
+
+    For example a ``lane_var = kv_idx`` and ``max_width = 8``:
+
+    - No dependency on lane var: ``q_idx`` returns
+      ``LaneExprInfo(is_uniform=True, is_contiguous=False, contiguous_width=None)``.
+    - ``kv_idx`` at an 8-aligned group start returns
+      ``LaneExprInfo(is_uniform=False, is_contiguous=True, contiguous_width=8)``.
+    - ``kv_idx + 4`` at a 4-aligned but not 8-aligned group start returns
+      ``LaneExprInfo(is_uniform=False, is_contiguous=False, contiguous_width=4)``.
+    - ``kv_idx * 2`` returns
+      ``LaneExprInfo(is_uniform=False, is_contiguous=False, contiguous_width=None)``.
+    """
+    if max_width <= 1:
+        return LaneExprInfo(True, False, None)
+
+    semantic_expr = V.graph.sizevars.simplify(expr)
+    if uniform_symbols is not None and semantic_expr.free_symbols <= uniform_symbols:
+        return LaneExprInfo(True, False, None)
+
+    lane_contiguity = V.graph.sizevars.analyze_lane_contiguity(semantic_expr, lane_var)
+    contiguous_width = aligned_contiguous_width(
+        semantic_expr,
+        lane_var,
+        max_width=max_width,
+        lane_contiguity=lane_contiguity,
+    )
+    return LaneExprInfo(
+        is_uniform=lane_contiguity.is_uniform_for(max_width),
+        is_contiguous=lane_contiguity.stride == 1 and contiguous_width == max_width,
+        contiguous_width=contiguous_width,
+    )
+
+
+def aligned_contiguous_width(
+    expr: sympy.Expr,
+    lane_var: sympy.Symbol,
+    *,
+    max_width: int,
+    lane_contiguity=None,
+) -> int | None:
+    """Return the largest aligned power-of-two contiguous lane width."""
+    assert max_width >= 2 and max_width.bit_count() == 1
+    if lane_contiguity is None:
+        lane_contiguity = V.graph.sizevars.analyze_lane_contiguity(expr, lane_var)
+    start_expr = lane_group_start(expr, lane_var)
+    width = max_width
+    while width >= 2:
+        if (
+            lane_contiguity.is_contiguous_for(width)
+            and V.graph.sizevars.statically_known_multiple_of(start_expr, width)
+            and V.graph.sizevars.statically_known_geq(start_expr, 0)
+        ):
+            return width
+        width //= 2
+    return None
+
+
+def lane_group_start(expr: sympy.Expr, lane_var: sympy.Symbol) -> sympy.Expr:
+    """Return the lane-group base value by evaluating ``expr`` at lane 0.
+
+    For example, if ``expr = base + lane_var``, this returns ``base``. This is
+    useful when checking vector-load alignment: a contiguous lane expression is only
+    safe to vectorize when the first lane's address is sufficiently aligned.
+    """
+    return V.graph.sizevars.simplify(expr.xreplace({lane_var: sympy.Integer(0)}))
+
+
+def decompose_affine_lane_expr(
+    expr: sympy.Expr, lane_var: sympy.Symbol
+) -> tuple[sympy.Expr, sympy.Expr] | None:
+    """Return ``(stride, base)`` when ``expr`` is affine in ``lane_var``.
+
+    The result satisfies ``expr == stride * lane_var + base``, where neither
+    ``stride`` nor ``base`` depends on ``lane_var``.
+    For example: ``stride == 0`` means lane-uniform, ``stride == 1`` means
+    consecutive lanes access consecutive indices, and other strides are
+    non-contiguous gathers.
+
+    Examples with ``lane_var = i``:
+        ``b + i`` -> ``(1, b)``
+        ``b + 2 * i`` -> ``(2, b)``
+        ``b`` -> ``(0, b)``
+
+    Returns ``None`` for non-affine expressions or when the extracted stride or
+    base still depends on ``lane_var``.
+    """
+    expr = V.graph.sizevars.simplify(expr)
+    lane_coeff = expr.coeff(lane_var)
+    rest = lane_group_start(expr, lane_var)
+    if lane_var in lane_coeff.free_symbols or lane_var in rest.free_symbols:
+        return None
+    residual = V.graph.sizevars.simplify(expr - (lane_coeff * lane_var + rest))
+    if residual != 0:
+        return None
+    return lane_coeff, rest

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -12,15 +12,23 @@ import torch
 import torch._inductor.config as inductor_config
 import torch.utils._pytree as pytree
 from torch._dynamo.utils import counters
+from torch._inductor.utils import get_gpu_type
 from torch.utils._debug_mode import DebugMode
 
 
 logger = torch._logging.getArtifactLogger(__name__, "benchmarking")
+
+
+def _has_gpu() -> bool:
+    gpu_type = get_gpu_type()
+    return getattr(torch, gpu_type).is_available()
+
+
 use_experimental_benchmarker = (
-    inductor_config.use_experimental_benchmarker and torch.cuda.is_available()
+    inductor_config.use_experimental_benchmarker and _has_gpu()
 )
 use_torch_profiler_benchmarker = (
-    inductor_config.use_torch_profiler_benchmarker and torch.cuda.is_available()
+    inductor_config.use_torch_profiler_benchmarker and _has_gpu()
 )
 
 
@@ -306,15 +314,18 @@ class Benchmarker:
         which eliminates kernel launch overhead for fair comparison between different
         implementations.
         """
+        from torch._dynamo.device_interface import get_interface_for_device
+
+        device_interface = get_interface_for_device(get_gpu_type())
         # Warmup
         _callable()
-        torch.cuda.synchronize()
+        device_interface.synchronize()
 
         # Capture into CUDA graph
         cuda_graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(cuda_graph, capture_error_mode="thread_local"):
             _callable()
-        torch.cuda.synchronize()
+        device_interface.synchronize()
 
         return self.benchmark_gpu(cuda_graph.replay, **kwargs)
 
@@ -400,28 +411,34 @@ class TritonBenchmarker(Benchmarker):
 
 class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
     @cached_property
+    def _device_interface(self: Self) -> Any:
+        from torch._dynamo.device_interface import get_interface_for_device
+
+        return get_interface_for_device(get_gpu_type())
+
+    @cached_property
     def L2_cache_size(self: Self) -> int:
         """Get the L2 cache size, in bytes, of the current device."""
-        device = torch.cuda.current_device()
-        props = torch.cuda.get_device_properties(device)
+        device = self._device_interface.current_device()
+        props = self._device_interface.get_device_properties(device)
         return props.L2_cache_size
 
     def get_event_pairs(
         self: Self, iters: int
-    ) -> list[tuple[torch.cuda.Event, torch.cuda.Event]]:
-        """Get `iters` pairs of CUDA events."""
+    ) -> list[tuple[Any, Any]]:
+        """Get `iters` pairs of device events."""
         return [
             (
-                torch.cuda.Event(enable_timing=True),
-                torch.cuda.Event(enable_timing=True),
+                self._device_interface.Event(enable_timing=True),
+                self._device_interface.Event(enable_timing=True),
             )
             for _ in range(iters)
         ]
 
     def get_event_pairs_min_timing(
-        self: Self, event_pairs: list[tuple[torch.cuda.Event, torch.cuda.Event]]
+        self: Self, event_pairs: list[tuple[Any, Any]]
     ) -> float:
-        """Get the minimum timing, in milliseconds, for a group of CUDA event pairs."""
+        """Get the minimum timing, in milliseconds, for a group of device event pairs."""
         return min(
             [
                 start_event.elapsed_time(end_event)
@@ -477,14 +494,16 @@ class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
             may_ban_benchmarking()
 
         # we don't want any outside errors propagating into benchmarking
-        torch.cuda.synchronize()
+        self._device_interface.synchronize()
 
         # warmup `_callable` (and catches any failures in the process)
         _callable()
-        torch.cuda.synchronize()
+        self._device_interface.synchronize()
 
         # see https://github.com/triton-lang/triton/pull/840 for why `dtype=torch.int`
-        buffer = torch.empty(self.L2_cache_size // 4, dtype=torch.int, device="cuda")
+        buffer = torch.empty(
+            self.L2_cache_size // 4, dtype=torch.int, device=get_gpu_type()
+        )
         buffer.zero_()
 
         # estimate the runtime of `_callable`
@@ -498,7 +517,7 @@ class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
             start_event.record()
             _callable()
             end_event.record()
-        torch.cuda.synchronize()
+        self._device_interface.synchronize()
         estimated_timing = self.get_event_pairs_min_timing(event_pairs)
 
         # adjust `benchmark_iters` to fit in the maximum benchmarking duration
@@ -522,7 +541,7 @@ class InductorBenchmarker(TritonBenchmarker):  # noqa: docstring_linter
             start_event.record()
             _callable()
             end_event.record()
-        torch.cuda.synchronize()
+        self._device_interface.synchronize()
 
         # explicitly delete the buffer, sometimes helps memory
         # footprint metrics in OSS Inductor performance benchmarks
@@ -591,11 +610,11 @@ class TorchProfilerBenchmarker(InductorBenchmarker):  # noqa: docstring_linter
         - The runtime of `_callable` in milliseconds, computed according to return_mode.
         """
         # we don't want any outside errors propagating into benchmarking
-        torch.cuda.synchronize()
+        self._device_interface.synchronize()
 
         # warmup `_callable` (and catches any failures in the process)
         _callable()
-        torch.cuda.synchronize()
+        self._device_interface.synchronize()
 
         # Keep Triton's 256 MB cache flush on ROCm. On other backends, reuse
         # the shared L2-sized flush from InductorBenchmarker.
@@ -604,7 +623,9 @@ class TorchProfilerBenchmarker(InductorBenchmarker):  # noqa: docstring_linter
             buffer_size_bytes = 256 * 1024 * 1024
         else:
             buffer_size_bytes = self.L2_cache_size
-        buffer = torch.empty(buffer_size_bytes // 4, dtype=torch.int, device="cuda")
+        buffer = torch.empty(
+            buffer_size_bytes // 4, dtype=torch.int, device=get_gpu_type()
+        )
         buffer.zero_()
 
         # Estimation phase with separate event pairs — also serves as warmup.
@@ -619,7 +640,7 @@ class TorchProfilerBenchmarker(InductorBenchmarker):  # noqa: docstring_linter
             start_event.record()
             _callable()
             end_event.record()
-        torch.cuda.synchronize()
+        self._device_interface.synchronize()
         estimated_ms = self.get_event_pairs_min_timing(event_pairs)
         if estimated_ms > 0:
             rep = max(min(rep, int(max_benchmark_duration / estimated_ms)), 1)
@@ -630,12 +651,17 @@ class TorchProfilerBenchmarker(InductorBenchmarker):  # noqa: docstring_linter
             buffer.zero_()
 
         # benchmark with profiler
-        # Use both CPU and CUDA activities, otherwise record_function
+        # Use both CPU and device activities, otherwise record_function
         # will not record the region.
+        gpu_type = get_gpu_type()
+        if gpu_type == "xpu":
+            profiler_activity = torch.profiler.ProfilerActivity.XPU
+        else:
+            profiler_activity = torch.profiler.ProfilerActivity.CUDA
         with torch.profiler.profile(
             activities=[
                 torch.profiler.ProfilerActivity.CPU,
-                torch.profiler.ProfilerActivity.CUDA,
+                profiler_activity,
             ],
             record_shapes=False,
         ) as prof:
@@ -648,7 +674,7 @@ class TorchProfilerBenchmarker(InductorBenchmarker):  # noqa: docstring_linter
                 with torch.profiler.record_function("_CALLABLE"):
                     _callable()
 
-        torch.cuda.synchronize()
+        self._device_interface.synchronize()
 
         # Extract _CALLABLE GPU time directly from raw kineto events.
         # This avoids prof.key_averages() which triggers expensive lazy
@@ -656,25 +682,35 @@ class TorchProfilerBenchmarker(InductorBenchmarker):  # noqa: docstring_linter
         # a Python FunctionEvent), _build_tree, and grouping/aggregation.
         from torch.autograd import DeviceType as _DeviceType
 
+        _device_type = (
+            _DeviceType.XPU if gpu_type == "xpu" else _DeviceType.CUDA
+        )
         callable_gpu_time_us = 0.0
+        callable_cpu_time_us = 0.0
         for kineto_event in prof.profiler.kineto_results.events():
-            if (
-                kineto_event.name() == "_CALLABLE"
-                and kineto_event.device_type() == _DeviceType.CUDA
-            ):
-                callable_gpu_time_us += (
+            if kineto_event.name() == "_CALLABLE":
+                event_device = kineto_event.device_type()
+                dur_us = (
                     kineto_event.end_ns() - kineto_event.start_ns()
                 ) / 1000.0
+                if event_device == _device_type:
+                    callable_gpu_time_us += dur_us
+                elif event_device == _DeviceType.CPU:
+                    callable_cpu_time_us += dur_us
 
-        if callable_gpu_time_us <= 0:
+        # Prefer GPU-side timing. Fall back to CPU-side timing when the
+        # backend (e.g. XPU) does not emit GPU_USER_ANNOTATION events for
+        # record_function regions.
+        callable_time_us = callable_gpu_time_us or callable_cpu_time_us
+        if callable_time_us <= 0:
             raise AssertionError(
-                "TorchProfilerBenchmarker: '_CALLABLE' CUDA event not found in "
+                "TorchProfilerBenchmarker: '_CALLABLE' GPU event not found in "
                 "raw kineto results. This indicates record_function('_CALLABLE') did "
                 "not produce a GPU_USER_ANNOTATION profiler event."
             )
 
         # TODO: Revisit incorporating launch overhead effects.
-        total_time_us = callable_gpu_time_us
+        total_time_us = callable_time_us
         avg_time_ms = (total_time_us / rep) / 1000.0
 
         # explicitly delete the buffer, sometimes helps memory

--- a/torch/_native/cutedsl_utils.py
+++ b/torch/_native/cutedsl_utils.py
@@ -44,6 +44,14 @@ def _check_runtime_available() -> tuple[bool, Version | None]:
     if not _cuda.is_built():
         return (False, None)
 
+    # CuTeDSL kernels require genuine NVIDIA GPUs; on ROCm/HIP builds the
+    # CUDA compatibility layer reports is_built()=True but cuInit() will fail
+    # because no NVIDIA driver is present.
+    import torch
+
+    if torch.version.hip is not None:
+        return (False, None)
+
     deps = [
         ("nvidia_cutlass_dsl", "cutlass"),
         ("apache_tvm_ffi", "tvm_ffi"),

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -393,6 +393,12 @@ class MockGraphHandler(GraphLowering):
         self.constants = {}
         self.scheduler = None
 
+    def try_get_buffer(self, buffer_name: str):
+        return self.name_to_buffer.get(buffer_name)
+
+    def get_buffer(self, buffer_name: str):
+        return self.name_to_buffer[buffer_name]
+
     def get_dtype(self, buffer_name: str) -> torch.dtype:
         """Return default dtype for any buffer (for testing)."""
         return torch.float32


### PR DESCRIPTION
## [cuda_xpu_alignment] DISABLED test_torch_profiler_benchmarker_reuses_inductor_helpers_hip_value0_expected_buffer_size_bytes_1024 (__main__.TestBenchmarker)

Fixes https://github.com/intel-sandbox/agentic_xpu/issues/51

**Root Cause:** The TorchProfilerBenchmarker.benchmark_gpu() in torch/_inductor/runtime/benchmarking.py hardcodes torch.cuda.synchronize() and device='cuda' throughout. On XPU-only builds without CUDA, this immediately raises 'Torch not compiled with CUDA enabled'. The entire benchmarking module lacks XPU device abstraction.

**Failed Tests:**
- `test/inductor/test_benchmarking.py::TestBenchmarker::test_torch_profiler_benchmarker_reuses_inductor_helpers_hip_value0_expected_buffer_size_bytes_1024`

---

**Failure Type:** NEW_FAILURE

---

**Diff stat:**
```
test/inductor/test_benchmarking.py      |   3 -
 torch/_inductor/runtime/benchmarking.py | 102 +++++++++++++++++++++-----------
 2 files changed, 69 insertions(+), 36 deletions(-)
```


